### PR TITLE
Refactor for many views

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
 	<script src="js/utils.js" type="text/javascript"></script>
 	<script src="js/draw.js" type="text/javascript"></script>
 	<script src="js/graph.js" type="text/javascript"></script>
+	<script src="js/reductions.js" type="text/javascript"></script>
 	<script src="js/conf.js" type="text/javascript"></script>
 	<script src="js/wildwebmidi.js" type="text/javascript"></script>
 	<script src="js/midiplayer.js" type="text/javascript"></script>
@@ -56,9 +57,8 @@
 	  </filter>
 	</svg>
 
-	<script src="js/main.js" type="text/javascript"></script>
-        <script type="text/javascript">
-        </script>
+        <script src="js/main.js" type="text/javascript">
+	</script>
 	<div id="selected_things" style="position:fixed; fill-opacity: 0.5;
 	stroke-opacity: 0.5">Primaries:<br/>Secondaries:</div>
 	<div id="hidden_buttons" style="position:fixed; bottom:0; z-index:2 ; display:none">

--- a/index.html
+++ b/index.html
@@ -102,7 +102,9 @@
         <!-- The div where we are going to insert the SVG -->
         <!--//////////////////////////////////////////////-->
 	
-	<div style="transform-origin: top left; z-index:-1" id="svg_output"></div>
+	<div style="transform-origin: top left; z-index:-1" id="svg_outputs">
+	<div id="svg_output0"></div>
+	</div>
 
 
 

--- a/index.html
+++ b/index.html
@@ -72,8 +72,8 @@
 	  <input type="button" id="deselectbutton" value="Deselect all" onclick="do_deselect()">
 	  <input type="button" id="deletebutton" value="Delete relations" onclick="delete_relations()" >
 	  <!--input type="button" id="edgebutton" value="Add untyped edges" onclick="do_edges()" -->
-	  <input type="button" class="relationbutton" id="relationbutton" value="Add untyped relation" onclick="do_relation()" > 
-	  <input type="button" class="relationbutton" id="customrelationbutton" value="Add relation with custom type:" onclick="do_relation($('#custom_type')[0].value)" >
+	  <input type="button" class="relationbutton" id="relationbutton" value="Add untyped relation" onclick="do_relation("",arg)" > 
+	  <input type="button" class="relationbutton" id="customrelationbutton" value="Add relation with custom type:" onclick="do_relation($('#custom_type')[0].value, arg)" >
 	  <input type="text" id="custom_type" onfocus="texton()" onblur="textoff()">
 	  <input type="button" id="midibutton" value="Play original" onclick="play_midi()" >
 	  <input type="button" id="midireducebutton" value="Play reduction" onclick="play_midi_reduction()" >

--- a/js/draw.js
+++ b/js/draw.js
@@ -1,7 +1,8 @@
 // Draw a series of edges (TODO: make it much much much better)
 function draw_edges() {
+  console.debug("Using globals: selected");
   var added = [];
-  if(selected.includes(undefined));
+  if(selected.includes(undefined))
     return [];
   for(var i = 1; i < selected.length; i++) {
     note1 = note_coords(selected[i-1]);
@@ -16,7 +17,11 @@ function draw_edges() {
 }
 
 // Draw a relation as a  series of edges (TODO: make it much much much better)
+// New version below as draw_relation_arg. It will draw based on
+// an already MEI-encoded relation rather than this ad-hoc
+// stuff.
 function draw_relation(id,type) {
+  console.debug("Using globals: selected, extraselected, mei, mei_graph, shades");
   var added = [];
   var notes = selected.concat(extraselected);
   if(notes.includes(undefined)) {
@@ -81,6 +86,7 @@ function draw_relation(id,type) {
 }
 
 function draw_metarelation(id,type) {
+  console.debug("Using globals: selected, extraselected, document, shades");
   var added = [];
   var targets =selected.concat(extraselected); 
   var coords = targets.map(get_metarelation_target);

--- a/js/graph.js
+++ b/js/graph.js
@@ -1,5 +1,6 @@
 // Add a collection of edges to the MEI graph element
 function add_edges(mei) {
+  console.debug("Using globals: selected, mei, mei_graph");
   var added = [];
   for(var i = 0; i < selected.length; i++) {
     var elem = add_mei_node_for(mei,mei_graph,selected[i]);
@@ -20,6 +21,7 @@ function add_edges(mei) {
 // Add a "relation" to the MEI graph element. We model this
 // with a new node.
 function add_relation(mei,mei_graph,type,he_id_param) {
+  console.debug("Using globals: selected, extraselected");
   var added = [];
   // Add new nodes for all notes
   for(var i = 0; i < selected.length; i++) {
@@ -70,6 +72,7 @@ function add_relation(mei,mei_graph,type,he_id_param) {
 }
 
 function add_metarelation(mei,mei_graph,type,he_id_param) {
+  console.debug("Using globals: mei, mei_graph, selected, extraselected");
   // Add a new node for the relation
   var added = [];
   var he_elem = mei.createElement("node");

--- a/js/graph.js
+++ b/js/graph.js
@@ -112,3 +112,93 @@ function add_metarelation(mei,mei_graph,type,he_id_param) {
   }
   return [he_id,added.reverse()];
 }
+
+
+// Add a "relation" to the MEI graph element. We model this
+// with a new node.
+function add_relation_arg(mei_graph, primaries, secondaries, type, he_id_param) {
+  var added = [];
+  // Add a new node for the relation
+  var he_elem = mei_graph.getRootNode().createElement("node");
+  he_elem.setAttribute("type","relation");
+  var he_label = mei_graph.getRootNode().createElement("label");
+  if(typeof type != 'undefined')
+    he_label.setAttribute("type",type)
+  he_elem.appendChild(he_label);
+  // Who knows if this is enough
+  var he_id;
+  if(typeof he_id_param == 'undefined')
+    he_id = "he-"+Math.floor(Math.random() * (1 << 20)).toString(16);
+  else
+    he_id = he_id_param;
+  he_elem.setAttribute("xml:id",he_id);
+  mei_graph.appendChild(he_elem);
+  added.push(he_elem);
+  for(var i = 0; i < primaries.length; i++) {
+    // So that we can refer to the node (not the note) ID in
+    // arcs/edges
+    var elem = mei.createElement("arc");
+    elem.setAttribute("from","#"+he_id);
+    elem.setAttribute("to","#"+primaries[i].getAttribute("xml:id"));
+    elem.setAttribute("type","primary");
+    mei_graph.appendChild(elem);
+    added.push(elem);
+  }
+  for(var i = 0; i < secondaries.length; i++) {
+    // So that we can refer to the node (not the note) ID in
+    // arcs/edges
+    var elem = mei.createElement("arc");
+    elem.setAttribute("from","#"+he_id);
+    elem.setAttribute("to","#"+secondaries[i].getAttribute("xml:id"));
+    elem.setAttribute("type","secondary");
+    mei_graph.appendChild(elem);
+    added.push(elem);
+  }
+  return [he_id,added.reverse()];
+}
+
+function add_metarelation_arg(mei_graph, primaries, secondaries, type,he_id_param) {
+  // Add a new node for the relation
+  //TODO: we use the id attribute of the selected
+  //primaries/secondaries. This is correct now, but needs
+  //refactoring when the interactions start being more
+  //complicated
+  var added = [];
+  var he_elem = mei_graph.getRootNode().createElement("node");
+  he_elem.setAttribute("type","metarelation");
+  var he_label = mei_graph.getRootNode().createElement("label");
+  if(typeof type != 'undefined')
+    he_label.setAttribute("type",type)
+  he_elem.appendChild(he_label);
+  // Who knows if this is enough
+  var he_id;
+  if(typeof he_id_param == 'undefined')
+    he_id = "he-"+Math.floor(Math.random() * (1 << 20)).toString(16);
+  else
+    he_id = he_id_param;
+  he_elem.setAttribute("xml:id",he_id);
+  mei_graph.appendChild(he_elem);
+  added.push(he_elem);
+  for(var i = 0; i < primaries.length; i++) {
+    // So that we can refer to the node (not the note) ID in
+    // arcs/edges
+    var elem = mei_graph.getRootNode().createElement("arc");
+    elem.setAttribute("from","#"+he_id);
+    elem.setAttribute("to","#"+primaries[i].getAttribute("xml:id"));
+    elem.setAttribute("type","primary");
+    mei_graph.appendChild(elem);
+    added.push(elem);
+  }
+  for(var i = 0; i < secondaries.length; i++) {
+    // So that we can refer to the node (not the note) ID in
+    // arcs/edges
+    var elem = mei_graph.getRootNode().createElement("arc");
+    elem.setAttribute("from","#"+he_id);
+    elem.setAttribute("to","#"+secondaries[i].getAttribute("xml:id"));
+    elem.setAttribute("type","secondary");
+    mei_graph.appendChild(elem);
+    added.push(elem);
+  }
+  return [he_id,added.reverse()];
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -66,6 +66,7 @@ $(document).ready(function()
 
 // Configured types need a button and a color each
 function init_type(type) {
+  console.debug("Using globals: document, shades_array, type_shades, type_keys, button_shades for conf");
   var elem = document.createElement("input");
   elem.setAttribute("type","button");
   elem.setAttribute("class","relationbutton");
@@ -80,6 +81,7 @@ function init_type(type) {
 
 // Configured meta types need a button and a color each
 function meta_type(type) {
+  console.debug("Using globals: document, shades_array, meta_shades, meta_keys, button_shades for conf");
   var elem = document.createElement("input");
   elem.setAttribute("type","button");
   elem.setAttribute("class","metarelationbutton");
@@ -94,6 +96,8 @@ function meta_type(type) {
 
 // If we're selecting relations, we may want to change them.
 function toggle_he_selected(selecting) {
+  console.debug("Using globals: document for changing button texts/visibility");
+
   Array.from(document.getElementsByClassName("relationbutton")).forEach((button) => {
         var val = button.getAttribute("value");
         if(selecting)
@@ -109,6 +113,7 @@ function toggle_he_selected(selecting) {
 
 // Toggle if a thing (for now: note or relation) is selected or not.
 function toggle_selected(item,extra) { 
+  console.debug("Using globals: selected, extraselected for adding/removing selected items. JQuery for changing displayed text of selected items");
   var ci = item.getAttribute("class");
   if(selected.length > 0 || extraselected.length > 0) {
     var csel = selected.concat(extraselected)[0].getAttribute("class");
@@ -173,6 +178,7 @@ function toggle_selected(item,extra) {
 
 // Toggle showing things other than notes in the score
 function toggle_equalize() {
+  console.debug("Using globals: non_notes_hidden");
   var hidden = "hidden";
   if(non_notes_hidden){
     hidden = "visible";
@@ -184,11 +190,11 @@ function toggle_equalize() {
 }
 
 function set_non_note_visibility(hidden) {
-  var svg_element = document.getElementById("svg_output");
-  Array.from(svg_element.getElementsByClassName("beam")).forEach((x) =>
+  console.debug("Using globals: document for element selection");
+  Array.from(document.getElementsByClassName("beam")).forEach((x) =>
       { Array.from(x.children).forEach((x) => { if(x.tagName == "polygon") { x.style.visibility= hidden; }})});
   hide_classes.forEach((cl) => {
-    Array.from(svg_element.getElementsByClassName(cl)).forEach((x) =>
+    Array.from(document.getElementsByClassName(cl)).forEach((x) =>
         { x.style.visibility= hidden; });
   })
 }
@@ -197,6 +203,7 @@ function set_non_note_visibility(hidden) {
 // Toggle the current relation having a type-dependent shade
 // or not
 function toggle_shade(he) {
+  console.debug("Using globals: shades, type_shades, meta_shades, type_synonym");
   if(!shades && he.getAttribute("old_fill")){
     he.setAttribute("fill",he.getAttribute("old_fill"));
     he.removeAttribute("old_fill");
@@ -213,6 +220,7 @@ function toggle_shade(he) {
 }
 
 function toggle_button_shade(button) {
+  console.debug("Using globals: shades, button_shades");
   if(shades) 
     button.style.color=button_shades[button.getAttribute("id")];
   else
@@ -221,6 +229,7 @@ function toggle_button_shade(button) {
 
 // Toggle type-dependent shades for relations and buttons
 function toggle_shades() {
+  console.debug("Using globals: shades, document for element selection");
   shades = !shades;
   Array.from(document.getElementsByClassName("relation")).forEach(toggle_shade);
   Array.from(document.getElementsByClassName("metarelation")).forEach(toggle_shade);
@@ -229,6 +238,7 @@ function toggle_shades() {
 }
 
 function delete_relation(elem) {
+  console.debug("Using globals: mei for element selection");
   //Assume no meta-edges for now, meaning we only have to
   //remove the SVG elem, the MEI node, and any involved arcs
   var orig_mei_he,mei_he = get_by_id(mei,elem.id);
@@ -260,6 +270,8 @@ function delete_relation(elem) {
 }
 
 function delete_relations() {
+  console.debug("Using globals: selected for element selection, undo_actions for storing the action");
+  //Assume no meta-edges for now, meaning we only have to
   if(selected.length == 0 || selected[0].getAttribute("class") != "relation"){
     console.log("No relation selected!");
     return;
@@ -342,6 +354,7 @@ function do_reduce() {
 // OK we've selected stuff, let's make the selection into a
 // series of edges
 function do_edges() {
+    console.debug("Using globals: selected, extraselected, mei, orig_mei, undo_actions");
     if (selected.length == 0 && extraselected == 0) {
       return;}
     changes = true;
@@ -414,6 +427,7 @@ function do_metarelation(type) {
 
 // Oops, undo whatever we did last.
 function do_undo() {
+    console.debug("Using globals: undo_actions, selected, extraselected, mei, rerendered_after_action");
     // Get latest undo_actions
     if(undo_actions.length == 0) {
       console.log("Nothing to undo");
@@ -477,6 +491,7 @@ function do_undo() {
 
 // We have keyboard commands!
 function handle_keypress(ev) {
+  console.debug("Using globals: text_input, meta_keys, type_keys");
   if(text_input)
     return;
   if (ev.key == "Enter"){
@@ -505,6 +520,7 @@ function handle_keypress(ev) {
 // Taken from StackOverflow answer by Kanchu at
 // https://stackoverflow.com/questions/13405129/javascript-create-and-save-file
 function download(data, filename, type) {
+    console.debug("Using globals: document, window");
     var file = new Blob([data], {type: type});
     if (window.navigator.msSaveOrOpenBlob) // IE10+
         window.navigator.msSaveOrOpenBlob(file, filename);
@@ -525,6 +541,7 @@ function download(data, filename, type) {
 // If the MEI already has a graph, we add on to that. TODO:
 // Check that the graph is actually our kind of graph
 function add_or_fetch_graph() {
+  console.debug("Using globals: mei");
   var existing = mei.getElementsByTagName("graph");
   if(existing.length) {
     // TODO: Not just grab the first one.
@@ -538,10 +555,12 @@ function add_or_fetch_graph() {
 
 // An option to download the MEI with the changes we've made
 function save() {
+  console.debug("Using globals: mei");
   var saved = new XMLSerializer().serializeToString(mei);
   download(saved, filename+".mei", "text/xml");
 }
 function save_orig() {
+  console.debug("Using globals: orig_mei");
   var saved = new XMLSerializer().serializeToString(orig_mei);
   download(saved, filename+".mei", "text/xml");
 }
@@ -554,6 +573,7 @@ function savesvg() {
 
 // Load a new MEI
 function load() {
+  console.debug("Using globals: selected_extraselected, upload, reader, filenmae");
   /* Cancel loading if changes are not saved? alert */
   selected = [];
   extraselected = [];
@@ -572,6 +592,7 @@ function load() {
 
 // Draw the existing graph
 function draw_graph() {
+  console.debug("Using globals: mei_graph, mei, selected, extraselected, document");
   // There's a multi-stage process to get all the info we
   // need... First we get the nodes from the graph element.
   var nodes_array = Array.from(mei_graph.getElementsByTagName("node"));
@@ -665,6 +686,7 @@ function draw_graph() {
 
 // Do all of this when we have the MEI in memory
 function load_finish(e) {
+  console.debug("Using globals data, parser, mei, format, svg, svg_elem, jquery document, document, mei_graph, midi, orig_*, changes, undo_cations, redo_actions, reduce_actions, rerendered_after_action, shades");
   data = reader.result;
   parser = new DOMParser();
   mei = parser.parseFromString(data,"text/xml");
@@ -717,6 +739,7 @@ function load_finish(e) {
 
 
 function rerender_mei(replace_with_rests = false) {
+  console.debug("Using globals mei, svg_elem");
   var mei2 = mei.implementation.createDocument(
         mei.documentElement.namespaceURI, //namespace to use
         null,             //name of the root element (or for empty document)
@@ -779,6 +802,7 @@ function rerender_mei(replace_with_rests = false) {
 }
 
 function rerender() {
+  console.debug("Using globals document, svg_elem, jquery document, svg, mei, data, mei_graph, non_notes_hidden, rerendered_after_action, undo_actions")
   // Create new SVG element, stack the current version on
   // it..? No I have no idea how to UI this properly.
   var mei2 = rerender_mei();

--- a/js/main.js
+++ b/js/main.js
@@ -722,7 +722,9 @@ function load_finish(e) {
 
   svg = vrvToolkit.renderData(data, {pageWidth: 20000,
       pageHeight: 10000, breaks: "none", format: format});
-  $("#svg_output").html(svg);
+  $("#svg_outputs").html('<div id="svg_output0"></div>')
+  $("#svg_output0").html(svg);
+  svg_elem = document.getElementById("svg_output0");
   if(format == "musicxml"){
     data = vrvToolkit.getMEI();
     parser = new DOMParser();
@@ -778,7 +780,7 @@ function rerender_mei(replace_with_rests = false) {
       );
   mei2.appendChild(newNode);
 
-  Array.from(document.getElementsByClassName("note")).forEach((x) => {
+  Array.from(svg_elem.getElementsByClassName("note")).forEach((x) => {
     if(x.style.visibility == "hidden"){
       //TODO: this is wrong
       // 
@@ -832,16 +834,31 @@ function rerender() {
   console.debug("Using globals document, svg_elem, jquery document, svg, mei, data, mei_graph, non_notes_hidden, rerendered_after_action, undo_actions")
   // Create new SVG element, stack the current version on
   // it..? No I have no idea how to UI this properly.
+  var output_parent = document.getElementById("svg_outputs");
+  var new_svg_elem = document.createElement("div");
+  var old_svg_elem = svg_elem;
+  new_svg_elem.setAttribute("id","svg_output" + output_parent.children.length);
+  output_parent.prepend(new_svg_elem);
+
   var mei2 = rerender_mei();
   var data2 = new XMLSerializer().serializeToString(mei2);
 
   var svg2 = vrvToolkit.renderData(data2, {pageWidth: 20000,
       pageHeight: 10000, breaks: "none", format: "mei"});
 
-  $("#svg_output").html(svg2);
+  draw_contexts[0].id_prefix = "old"+(output_parent.children.length-2);
+  prefix_ids(old_svg_elem,draw_contexts[0].id_prefix);
+  
+  $(new_svg_elem).html(svg2);
+  var new_draw_context = {"mei": mei2, "svg_elem" : new_svg_elem,
+    "id_prefix" : ""};
+  draw_contexts.reverse();
+  draw_contexts.push(new_draw_context);
+  draw_contexts.reverse();
   svg = svg2;
   mei = mei2;
   data = data2;
+  svg_elem = new_svg_elem;
   mei_graph = add_or_fetch_graph();
   for (let n of document.getElementsByClassName("note")) {
       n.onclick= function(ev) {toggle_selected(n,ev.shiftKey) };
@@ -872,11 +889,11 @@ function hide_buttons() {
 
 function zoom_in() {
   zoom = zoom * 1.1;
-  $("#svg_output")[0].style.transform="scale("+zoom+")";
+  $("#svg_outputs")[0].style.transform="scale("+zoom+")";
 }
 function zoom_out() {
   zoom = zoom * 0.90909090909090;
-  $("#svg_output")[0].style.transform="scale("+zoom+")";
+  $("#svg_outputs")[0].style.transform="scale("+zoom+")";
 }
 
 

--- a/js/reductions.js
+++ b/js/reductions.js
@@ -1,0 +1,81 @@
+function calc_reduce_arg(mei_graph, remaining_relations, target_relations){
+  // No primary of a remaining relation is removed in this
+  // reduction
+  var remaining_nodes = remaining_relations.map(
+    		      (he) => relation_primaries_arg(mei_graph,he)
+    		    ).flat();
+  // We know that the remaining relations that have not been
+  // selected for reduction will remain
+  remaining_relations = remaining_relations.filter((x) => {return !target_relations.includes(x);});
+  // So all of their nodes should be added to the remaining
+  // nodes, not just the primaries
+  remaining_nodes = remaining_nodes.concat(remaining_relations.map(
+    		  (he) => relation_secondaries_arg(mei_graph,he)
+    		).flat());
+
+  do {
+    // We want to find more relations that we know need to stay 
+    var more_remains = target_relations.filter((he) => { 
+        // That is, relations that have, as secondaries, nodes
+        // we know need to stay
+        return (relation_secondaries_arg(mei_graph,he).findIndex((x) => {return remaining_nodes.includes(x);}) > -1);
+      });
+    // Add those relations to the ones that need to stay
+    remaining_relations = remaining_relations.concat(more_remains);
+    // And remove them from those that may be removed
+    target_relations = target_relations.filter((x) => {return !more_remains.includes(x);})
+    // And update the remaining nodes
+    remaining_nodes = remaining_nodes.concat(more_remains.map(
+    		    (he) => relation_secondaries_arg(mei_graph,he)
+    		  ).flat());
+  // Until we reach a pass where we don't find any more
+  // relations that need to stay
+  }while(more_remains.length > 0)
+  // Any relations that remain after this loop, we can remove,
+  // including their secondaries
+
+  return [target_relations, 
+          [...new Set(target_relations.flatMap(
+            (he) => relation_secondaries_arg(mei_graph,he)
+          ))]];
+
+}
+
+
+// Do a reduction in the context, using the given graph and the
+// (optional) selected hyperedges from this context.
+function do_reduce_arg(draw_context, mei_graph, selection){
+  var target_relations = selection.map(
+        (ge) => get_by_id(mei_graph.getRootNode(), id_or_oldid(ge))
+      );
+
+  var all_relations_nodes = Array.from(mei_graph.getElementsByTagName("node")).filter((x) => { return x.getAttribute("type") == "relation";});
+
+  var remaining_relations = all_relations_nodes.filter(
+        (n) => {
+           var g = get_by_id(document,draw_context.id_prefix + n.getAttribute("xml:id"));
+           return g != undefined && g.style.visibility != "hidden";
+         }
+      );
+
+  if(target_relations.length == 0)
+    target_relations = remaining_relations;
+
+  // The removed notes we get are _nodes in the graph_, but
+  // hide_note_arg is built with that in mind.
+  var [removed_relations, removed_notes] = calc_reduce_arg(mei_graph, 
+                                                           remaining_relations, 
+    						       target_relations);
+  var graphicals =[];
+  graphicals.push(removed_relations.map(
+    		(r) => hide_he_arg(draw_context,r)
+    	      ));
+
+  graphicals.push(removed_notes.map(
+                      (n) => hide_note_arg(draw_context,n)
+    	      ));
+
+  return [removed_relations,removed_notes,graphicals];
+}
+
+

--- a/js/utils.js
+++ b/js/utils.js
@@ -138,11 +138,13 @@ function circle(p,rad) {
 function add_to_svg_bg(newElement) {
   var sibling = document.getElementsByClassName("system")[0];
   var parent = sibling.parentNode;
+  console.debug("Using global: document to get 'system' element");
   parent.insertBefore(newElement,sibling);
 }
 
 function add_to_svg_fg(newElement) {
   var sibling = document.getElementsByClassName("system")[0];
+  console.debug("Using global: document to get 'system' element");
   var parent = sibling.parentNode;
   parent.appendChild(newElement);
 }
@@ -150,6 +152,7 @@ function add_to_svg_fg(newElement) {
 
 function g() {
   var newElement = document.createElementNS("http://www.w3.org/2000/svg", 'g');
+  console.debug("Using global: document to create new element");
   return newElement;
 }
 
@@ -172,6 +175,7 @@ function get_by_id(doc,id) {
 
 // From graph node to list of all arcs that refer to it
 function node_referred_to(id) {
+  console.debug("Using global: mei to find element");
   return Array.from(mei.getElementsByTagName("arc"))
     .filter((x) => {
 	return (x.getAttribute("from") == "#"+id || 
@@ -193,6 +197,7 @@ function mod(n, m) {
 
 // What's the accidentals for this note?
 function note_get_accid(note) {
+  console.debug("Using globals: document, mei to find element");
   if(document.contains(note))
     note = get_by_id(mei,note.id);
   if(note.hasAttribute("accid.ges"))
@@ -214,6 +219,7 @@ function note_get_accid(note) {
 
 // Get the timestamp for a note
 function get_time(note) {
+  console.debug("Using globals: document, mei to find element");
   if(document.contains(note))
     note = get_by_id(mei,note.id);
   return vrvToolkit.getTimeForElement(note.getAttribute("xml:id"));
@@ -222,6 +228,7 @@ function get_time(note) {
 
 // From any relation element to list of MEI note elements
 function relation_get_notes(he) {
+  console.debug("Using globals: document, mei to find element");
   if(document.contains(he))
     he = get_by_id(mei,he.id);
   var note_nodes = relation_allnodes(he);
@@ -231,6 +238,7 @@ function relation_get_notes(he) {
 }
 // From any relation element to list of MEI note elements
 function relation_get_notes_separated(he) {
+  console.debug("Using globals: document, mei to find element");
   if(document.contains(he))
     he = get_by_id(mei,he.id);
   var prim_nodes = relation_primaries(he);
@@ -242,6 +250,7 @@ function relation_get_notes_separated(he) {
 
 // Get the MEI-graph nodes that are adjacent to a relation
 function relation_allnodes(he) {
+  console.debug("Using globals: mei, mei_graph to find graph connections");
   var arcs_array = Array.from(mei_graph.getElementsByTagName("arc"));
   var nodes = [];
   arcs_array.forEach((a) => {
@@ -253,6 +262,7 @@ function relation_allnodes(he) {
 }
 // Get the MEI-graph nodes that are adjacent and primary to a relation
 function relation_primaries(he) {
+  console.debug("Using globals: mei, mei_graph to find graph connections");
   var arcs_array = Array.from(mei_graph.getElementsByTagName("arc"));
   var nodes = [];
   arcs_array.forEach((a) => {
@@ -265,6 +275,7 @@ function relation_primaries(he) {
 }
 // Get the MEI-graph nodes that are adjacent and secondary to a relation
 function relation_secondaries(he) {
+  console.debug("Using globals: mei, mei_graph to find graph connections");
   var arcs_array = Array.from(mei_graph.getElementsByTagName("arc"));
   var nodes = [];
   arcs_array.forEach((a) => {
@@ -278,6 +289,7 @@ function relation_secondaries(he) {
 
 // Set up new graph node for a note
 function add_mei_node_for(mei,mei_graph,note) {
+    console.debug("Using globals: mei, mei_graph to create and place elem");
     var id = note.getAttribute("id");
     var elem = get_by_id(mei,"gn-"+id);
     if (elem != null) {
@@ -298,6 +310,7 @@ function add_mei_node_for(mei,mei_graph,note) {
             
 // Find graphical element and hide it
 function hide_note(note) {
+  console.debug("Using globals: document to find elem");
   var elem = get_by_id(document,note_get_sameas(note));
   if(elem)
     elem.style.visibility = "hidden";
@@ -306,6 +319,7 @@ function hide_note(note) {
 
 // Find graphical element and hide it
 function hide_he(he) {
+  console.debug("Using globals: document to find elem");
   var elem = get_by_id(document,he.getAttribute("xml:id"));
   if(elem) 
     elem.style.visibility = "hidden";
@@ -328,6 +342,7 @@ function unmark_secondary(item) {
 
 // For a certain relation, find its secondaries and mark them
 function mark_secondaries(he) {
+    console.debug("Using globals: document, mei to find elems");
     if(!mei.contains(he))
       he = get_by_id(mei,he.id);
     var secondaries = relation_secondaries(he);
@@ -339,6 +354,7 @@ function mark_secondaries(he) {
 
 // For a certain relation, find its secondaries and unmark them
 function unmark_secondaries(he) {
+    console.debug("Using globals: document, mei to find elems");
     if(!mei.contains(he))
       he = get_by_id(mei,he.id);
     var secondaries = relation_secondaries(he);
@@ -355,6 +371,7 @@ function get_measure(elem) {if(elem.tagName == "measure") return elem; else retu
 // pitch in this measure, and select them as secondary, and the previously
 // selected one as primary
 function select_samenote() {
+  console.debug("Using globals: document, mei to find elems");
   if((selected.length == 1 || extraselected.length == 1)
    && !(selected.length == 1 &&  extraselected.length == 1)){
     var svg_note;

--- a/plans
+++ b/plans
@@ -28,7 +28,6 @@ The intermediate scores (and their renderings).
 And, of course a bunch of other things.
 
 
-
 Steps:
 
 1. Load MEI/XML
@@ -52,5 +51,79 @@ Steps:
 9. Automatically choose edges to hide
 
 10. Slide through more or less reduced version of the score
+
+
+2020-12-18 - Refactoring for multiple views
+
+The idea is to (eventually) have multiple active renderings of different
+stages of reduction ("layers"), that the user can all interact with.
+
+Problem: IDs are supposed to be unique in an XHTML file. 
+Solution: Namespace the SVG id's.
+
+There are a number of further subtleties that need solving. In particular
+how different XML documents and XML document sections relate to each other.
+For the first few steps below, there will be a number of SVG parts of the
+XHTML document that all relate to a single MEI document, and therein a
+single score and a single graph. Later versions will likely have also
+several MEI elements each containing a new layer the analysis.
+
+We need to consider what operations do at various levels.
+
+Is there only one graph? (Yes)
+
+Does adding a relation in one view/layer add it to the others? (Yes)
+
+Can reductions be done in any layer or just the latest? (Only the latest for now)
+
+Can notes be added in any layer or just the latest? (Only the latest for now)
+
+OK, so this is the plan:
+
+1. Each "view" has an id_prefix, an SVG elem, it's own view of the MEI.
+2. a drawing context which is the above
+3. draw_* takes an element from the MEI and and a drawing context and adds
+the requisite element to the SVG if all notes are present, visible if all
+notes are visible
+4. shades/non_note_ remains global
+
+Steps:
+
+1. Rerender statically, leave the old.
+
+2. Go back to the initial view of each layer after the reduction has been
+   rendered.
+
+3. Start working on the XML relations and multiple layers.
+   * refactor draw_* to read stuff from a <graph> node, and feed it a
+     "drawing context" containing svg element, potential prefix, etc.
+
+
+
+
+UI ideas:
+
+Highlight (copies of) entities in all views on hover.
+
+Highlight the currently active view(s)
+
+Separate options for "layers" and "views". Add ability to expand/collapse
+views from layers. Layers exist in the MEI, views do not.
+
+Code ideas:
+
+Separate global actions from local actions. 
+  Global actions are for example:
+    * Adding/deleting relations
+    * Adding views
+  Local/view actions are for example:
+    * Reductions
+    * Merging staves?
+  (future)Actions local to a layer are for example:
+    * Adding implied tones
+    * Shifting notes and tones 
+
+
+
 
 


### PR DESCRIPTION
This is a rather large refactoring with minimal actual impact. The old code remains, largely, while new code has been added that relies significantly less on globals and more on arguments being passed around. In particular, this leads to the opportunity to implement properly a concept of multiple _views_ of the same underlying MEI graph, using `draw_context`s, containing references to an SVG element and the MEI, with an `id_prefix` that specifies how the XML IDs of the MEI relate to those in the SVG. The behavioural changes are disabled by a switch (the global `arg`) by default.

There are also a lot of `console.debug` messages that go on about what globals are used in each function.

The old code will be considered deprecated from the next version, and the switch to the new and deletion of the old will happen in the one after that. 