### PR TITLE
Deselect objects and delete relations via the keyboard.

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
 	  <div id="meta_buttons" style="display:none">
 	  </div>
 	  <input type="button" id="undobutton" value="(U)ndo" onclick="do_undo()">
-	  <input type="button" id="deselectbutton" value="Deselect all" onclick="do_deselect()">
-	  <input type="button" id="deletebutton" value="Delete relations" onclick="delete_relations()" >
+	  <input type="button" id="deselectbutton" value="(d)eselect all" onclick="do_deselect()">
+	  <input type="button" id="deletebutton" value="(D)elete relations" onclick="delete_relations()" >
 	  <!--input type="button" id="edgebutton" value="Add untyped edges" onclick="do_edges()" -->
 	  <input type="button" class="relationbutton" id="relationbutton" value="Add untyped relation" onclick="do_relation("",arg)" > 
 	  <input type="button" class="relationbutton" id="customrelationbutton" value="Add relation with custom type:" onclick="do_relation($('#custom_type')[0].value, arg)" >

--- a/js/main.js
+++ b/js/main.js
@@ -305,6 +305,12 @@ function delete_relation(elem) {
   var removed = arcs.concat(orig_arcs).concat([elem,mei_he,orig_mei_he]);
   var action_removed = removed.map((x) => {if(x != undefined){
       var elems = [x,x.parentElement,x.nextSibling]; 
+      // If x corresponds to an SVG note (try!), un-style it as if we were not hovering over the relation.
+      // This is necessary when deleting via they keyboard (therefore while hovering).
+      try {
+        $(`g #${x.getAttribute('to').substring(4)}`).removeClass().addClass('note');
+      } catch {
+      }
       x.parentElement.removeChild(x);
       return elems;
       }});
@@ -649,6 +655,10 @@ function handle_keypress(ev) {
   } else if (ev.key == "+") { // Select same notes in the measure
     select_samenote();
     do_relation("repeat",arg);
+  } else if (ev.key == "d") { // Deselect all.
+    do_deselect();
+  } else if (ev.key == "D") { // Delete relations.
+    delete_relations();
   } else if (type_keys[ev.key]) { // Add a relation
     do_relation(type_keys[ev.key],arg);
   } else if (meta_keys[ev.key]) { // Add a relation


### PR DESCRIPTION
This PR adds <kbd>d</kbd> and <kbd>D</kbd> shortcuts for de-selecting and deleting, respectively.

Partly in response to #32, which proved to be a real usability issue during corpus building.

