### PR TITLE
Delete metarelations

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
 	  </div>
 	  <input type="button" id="undobutton" value="(U)ndo" onclick="do_undo()">
 	  <input type="button" id="deselectbutton" value="(d)eselect all" onclick="do_deselect()">
-	  <input type="button" id="deletebutton" value="(D)elete relations" onclick="delete_relations()" >
+	  <input type="button" id="deletebutton" value="(D)elete (meta)relations" onclick="delete_relations()" >
 	  <input type="button" class="relationbutton" id="relationbutton" value="Add untyped relation" onclick="do_relation("")" > 
 	  <input type="button" class="relationbutton" id="customrelationbutton" value="Add relation with custom type:" onclick="do_relation($('#custom_type')[0].value)" >
 	  <input type="text" id="custom_type" onfocus="texton()" onblur="textoff()">

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
 	<script src="js/utils.js" type="text/javascript"></script>
 	<script src="js/draw.js" type="text/javascript"></script>
 	<script src="js/graph.js" type="text/javascript"></script>
+	<script src="js/delete.js" type="text/javascript"></script>
 	<script src="js/reductions.js" type="text/javascript"></script>
 	<script src="js/layers.js" type="text/javascript"></script>
 	<script src="js/coordinates.js" type="text/javascript"></script>

--- a/js/delete.js
+++ b/js/delete.js
@@ -1,0 +1,57 @@
+
+function delete_relation(elem) {
+  console.debug("Using globals: mei for element selection");
+  //Assume no meta-edges for now, meaning we only have to
+  //remove the SVG elem, the MEI node, and any involved arcs
+  var mei_id = get_id(elem);
+  var mei_he = get_by_id(mei,mei_id);
+  var svg_hes = [];
+  var metarel = get_class_from_classlist(elem);
+  for(draw_context of draw_contexts){
+    let svg_he = get_by_id(document,draw_context.id_prefix + mei_id);
+    if(svg_he){
+      svg_hes.push(svg_he);
+      if(!metarel)
+	unmark_secondaries(draw_context, mei_graph, mei_he);
+    }
+  }
+
+  
+  var arcs =
+    Array.from(mei.getElementsByTagName("arc")).filter((arc) =>
+      {
+       return arc.getAttribute("to") == "#"+elem.id ||
+              arc.getAttribute("from") == "#"+elem.id;
+      });
+  var removed = arcs.concat(svg_hes);
+  removed.push(mei_he);
+  var action_removed = removed.map((x) => {
+      var elems = [x,x.parentElement,x.nextSibling]; 
+      // If x corresponds to an SVG note (try!), un-style it as if we were not hovering over the relation.
+      // This is necessary when deleting via they keyboard (therefore while hovering).
+      try {
+        $(`g #${x.getAttribute('to').substring(4)}`).removeClass().addClass('note');
+      } catch (e) {
+      }
+      x.parentElement.removeChild(x);
+      return elems;
+    });
+
+  return action_removed;
+}
+
+function delete_relations() {
+  console.debug("Using globals: selected for element selection, undo_actions for storing the action");
+  //Assume no meta-edges for now, meaning we only have to
+  var sel = selected.concat(extraselected);
+  if(sel.length == 0 || !(get_class_from_classlist(sel[0]) == "relation" ||
+	                  get_class_from_classlist(sel[0]) == "metarelation")){
+    console.log("No (meta)relation selected!");
+    return;
+  }
+  var removed = sel.flatMap(delete_relation);
+  undo_actions.push(["delete relation",removed.reverse(),selected,extraselected]);
+  sel.forEach(toggle_selected);
+}
+
+


### PR DESCRIPTION
This allows the same mechanisms that delete relations to also delete metarelations. Note that this is at least graphically _buggy_ - we just delete arcs where the (meta)relations appear, we don't modify SVG elements that are not the deleted relation or targetted notes.

This thus fixes #62, but not #63