### PR TITLE
Use transparency in relations panel for less obstructed score view.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -693,7 +693,6 @@ margin-top: 0.5rem;
   text-align: left;
   cursor: move;
   z-index: 10;
-  background-color: #2196F3;
   color: white;
   display: flex;
 }
@@ -704,10 +703,8 @@ margin-top: 0.5rem;
 }
 
 #relation_buttons, #meta_buttons, #combo_buttons {
-  background: #dfdfdf;
   margin: 5px;
   border-radius: 10px;
-  box-shadow: inset 1px 1px 1px grey;
   padding: 5px;
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -617,11 +617,7 @@ function handle_hull_controller() {
 
 function handle_relations_panel(el) {
   var newX = 0, newY = 0, curX = 0, curY = 0;
-  if (document.getElementById(el.id + "_header")) {
-    document.getElementById(el.id + "_header").onmousedown = startDragging;
-  } else {
-    elmnt.onmousedown = startDragging;
-  }
+  el.onmousedown = startDragging;
 
   function startDragging(e) {
     e = e || window.event;


### PR DESCRIPTION
The relations panel may now be dragged from any point on its surface, not only the title bar.