### PR TITLE
Toggle (hide/show) notes not participating in any relation (<arc>).

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
 	    </div>
 	    <input type="button" id="equalizebutton" value="Toggle (s)tems etc." onclick="toggle_equalize()" >
 	    <input type="button" id="shadesbutton" value="Toggle type s(h)ades." onclick="toggle_shades()" >
+	    <input type="button" id="shadesbutton" value="Toggle non-related tones." onclick="toggle_orphan_notes()" >
 	  </div>
 	</div>
 	<div id="metadata_input" class="metadata_input">

--- a/js/ui.js
+++ b/js/ui.js
@@ -23,6 +23,9 @@ var extraselected = [];
 // Last-selected entity in the current selection.
 var last_selected = null;
 
+// Show non-related ("orphan") notes by default.
+var show_orphans = true;
+
 // Toggle if a thing (for now: note or relation) is selected or not.
 function toggle_selected(item,extra) { 
   console.debug("Using globals: selected, extraselected for adding/removing selected items. JQuery for changing displayed text of selected items");
@@ -942,3 +945,24 @@ function jump_to_adjacent_context(direction = 1) {
   if (element_index != -1) moveTo(contexts[element_index].view_elem);
 }
 
+function hide_orphan_notes() {
+  var ids = Array.from(document.getElementsByClassName('note')).map(e => e.id);
+  var gn_ids = Array.from(mei_graph.getElementsByTagName('arc')).map(e => e.getAttribute("to"));
+console.log(ids); console.log(gn_ids)
+  ids.forEach(i => {
+    if (!gn_ids.includes(`#gn-${i}`))
+      document.getElementById(i).classList.add('hidden')
+    else
+      console.log(i)
+  })
+
+}
+
+function show_all_notes() {
+  Array.from(document.querySelectorAll('g.note')).forEach(e => e.classList.remove('hidden'));
+}
+
+function toggle_orphan_notes() {
+  show_orphans = !show_orphans;
+  show_orphans ? show_all_notes() : hide_orphan_notes();
+}


### PR DESCRIPTION
Not all notes are always relevant to an encoding or analysis. This PR provides facilities (button and routines) for toggling "non-related" notes, i.e. those that do not participate in any `<arc>` element.

(This does not quite address #104, which would require fundamental design changes to be useful—for example, the stripping of metric information from the the score.)