### PR TITLE
Remove wrongful checks on original_score attribute of draw contexts

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -484,7 +484,6 @@ function load_finish(loader_modal) {
       'layer_number': 0,
       'score_elem': score_elem,
       'id_mapping': get_id_pairs(score_elem),
-      'original_score': i == 0, // The first layer is assumed to be the original score
       'number_of_views': 1
     }
 
@@ -588,7 +587,6 @@ export function create_new_layer(draw_context, sliced = false, tied = false) {
     'layer_number': layer_contexts.length,
     'score_elem': new_score_elem,
     'id_mapping': get_id_pairs(new_score_elem),
-    'original_score': false,
     'number_of_views': 1,
   }
   layer_contexts.push(layer_context)

--- a/src/js/coordinates.js
+++ b/src/js/coordinates.js
@@ -309,7 +309,7 @@ export function do_note(pname, oct, note, offset, id, redoing = false) {
 export function place_note() {
   var current_draw_context = getCurrentDrawContext()
   var placing_note = getPlacingNote()
-  if (placing_note != '' && !current_draw_context.layer.original_score) {
+  if (placing_note != '' && (get_by_id(document, current_draw_context.id_prefix + 'editcb').checked)) {
     let [pname, oct, note] = note_params()
     if (!pname)
       return
@@ -345,7 +345,7 @@ export function stop_placing_note() {
 export function toggle_placing_note() {
   var current_draw_context = getCurrentDrawContext()
   var placing_note = getPlacingNote()
-  if (!current_draw_context?.layer.original_score) {
+  if ((get_by_id(document, current_draw_context.id_prefix + 'editcb').checked)) {
     if (placing_note) {
       stop_placing_note()
       return false
@@ -358,7 +358,7 @@ export function toggle_placing_note() {
 
 export function update_placing_note() {
   var current_draw_context = getCurrentDrawContext()
-  if (current_draw_context.layer.original_score)
+  if (!(get_by_id(document, current_draw_context.id_prefix + 'editcb').checked)) {
     return
   let [pname, oct, note] = note_params()
   if (pname) {


### PR DESCRIPTION
This attribute should no longer matter, and we should instead check the "editcb" checkbox for whether or not we're allowed to add notes.