### PR TITLE
Add main menu and start screen

### DIFF
--- a/public/components.html
+++ b/public/components.html
@@ -30,6 +30,18 @@
 
 <body>
 
+    <!-- Loading -->
+    <div>
+        <div class="loading-spinner">
+            <div class="loading-spinner__disc"></div>
+            <div class="loading-spinner__disc"></div>
+            <div class="loading-spinner__disc"></div>
+            <div class="loading-spinner__disc"></div>
+            <div class="loading-spinner__disc"></div>
+        </div>
+        <p>Loading</p>
+    </div>
+
     <!-- Fly-out with a notch -->
 
     <div class="fly-out fly-out--big fly-out--dark">

--- a/public/components.html
+++ b/public/components.html
@@ -370,6 +370,7 @@
 
     </div>
 
+    <!-- Main menu button -->
     <button class="btn btn--plain" type="button">
         Menu
         <svg class="btn__icon" width="15" height="10">
@@ -377,13 +378,15 @@
         </svg>
     </button>
 
-    <div class="fly-out fly-out--dark fly-out--collapsible fly-out--expanded">
+    <!-- Main menu fly-out -->
+
+    <div class="fly-out fly-out--dark fly-out--collapsible fly-out--expanded fly-out--main-menu">
 
         <h3 class="fly-out__toggle">
             <button id="menu-toggle" class="btn btn--plain fly-out__toggleBtn" type="button">
                 Menu
-                <svg class="btn__icon" width="20" height="10">
-                    <use xlink:href="#filter-path"/>
+                <svg width="11" height="11">
+                    <use xlink:href="#cross-path"/>
                 </svg>
             </button>
         </h3>
@@ -391,9 +394,9 @@
         <div class="fly-out__inner">
             <h4 class="fly-out__title">File</h4>
             <div class="btn-group">
-                <button class="btn btn--plain" type="button">Save file</button>
-                <button class="btn btn--plain" type="button"><span>Save as <abbr title="Scalable Vector Graphics">SVG</abbr></span></button>
-                <label class="file | btn btn--plain" for="file">
+                <button class="btn btn--plain btn--small" type="button">Save file</button>
+                <button class="btn btn--plain btn--small" type="button"><span>Save as <abbr title="Scalable Vector Graphics">SVG</abbr></span></button>
+                <label class="file | btn btn--plain btn--small" for="file">
                     <span>
                         Select a <abbr title="Music Encoding Initiative">MEI</abbr> file
                         <input class="file__input" id="file" type="file" accept=".mei">
@@ -500,37 +503,6 @@
         </svg>
         Naturalize note
     </button>
-
-    <!-- Menu fly-out -->
-
-    <div class="fly-out fly-out--dark fly-out--collapsible fly-out--expanded">
-
-        <h3 class="fly-out__toggle">
-            <button id="menu-toggle" class="btn btn--plain fly-out__toggleBtn" type="button">
-                Menu
-                <svg class="btn__icon" width="20" height="10">
-                    <use xlink:href="#filter-path"/>
-                </svg>
-            </button>
-        </h3>
-
-        <div class="fly-out__inner">
-            <h4 class="fly-out__title">File</h4>
-            <div class="btn-group">
-                <button class="btn btn--plain" type="button">Save file</button>
-                <button class="btn btn--plain" type="button"><span>Save as <abbr title="Scalable Vector Graphics">SVG</abbr></span></button>
-                <label class="file | btn btn--plain" for="file">
-                    <span>
-                        Select a <abbr title="Music Encoding Initiative">MEI</abbr> file
-                        <input class="file__input" id="file" type="file" accept=".mei">
-                    </span>
-                </label>
-            </div>
-            <hr class="fly-out__hr">
-            <h4 class="fly-out__title">Relations settings</h4>
-        </div>
-
-    </div>
 
     <!-- Spritesheet -->
 

--- a/public/index.html
+++ b/public/index.html
@@ -67,7 +67,59 @@
 
         <div id="menu-and-filters" class="menu-and-filters">
 
-            <p>Menu</p>
+            <!-- Main menu fly-out -->
+
+            <div id="main-menu" class="fly-out fly-out--dark fly-out--collapsible fly-out--collapsed fly-out--main-menu">
+
+                <!-- Collapsed, in case the expanded menu must overlap the filters one.
+                    For that, 1) make the expanded version by position: absolute,
+                    2) make this one disabled 3) hide it (opacity 0)
+                 -->
+                <!-- <h3 class="fly-out__toggle">
+                    <button id="menu-toggle" class="btn btn--plain fly-out__toggleBtn" type="button">
+                        Menu
+                        <svg class="btn__icon" width="15" height="10">
+                            <use xlink:href="#menu-path"/>
+                        </svg>
+                    </button>
+                </h3> -->
+
+                <!-- Expanded -->
+                <h3 class="fly-out__toggle">
+                    <button id="main-menu-toggle" class="btn btn--plain fly-out__toggleBtn" type="button">
+                        Menu
+                        <!-- Expanded -->
+                        <svg class="fly-out__hideIfCollapsed" width="11" height="11">
+                            <use xlink:href="#cross-path"/>
+                        </svg>
+                        <!-- Collapsed -->
+                        <svg class="fly-out__hideIfExpanded" width="15" height="10">
+                            <use xlink:href="#menu-path"/>
+                        </svg>
+                    </button>
+                </h3>
+
+                <div class="fly-out__inner">
+                    <h4 class="fly-out__title">File</h4>
+
+                    <div class="btn-group">
+                        <button id="save-file" class="btn btn--plain btn--small" type="button">Save file</button>
+
+                        <button id="save-file-svg" class="btn btn--plain btn--small" type="button">
+                            <span>Save as <abbr title="Scalable Vector Graphics">SVG</abbr></span>
+                        </button>
+
+                        <label class="file | btn btn--plain btn--small" for="score-file-picker">
+                            <span>
+                                Select a <abbr title="Music Encoding Initiative">MEI</abbr> file
+                                <input class="file__input" id="score-file-picker" type="file" accept=".mei">
+                            </span>
+                        </label>
+                    </div>
+                </div>
+
+            </div>
+
 
             <div id="filters" class="fly-out fly-out--dark fly-out--collapsible fly-out--collapsed">
 
@@ -379,9 +431,6 @@
             <br>
         </div>
         <div id="main_buttons_content">
-            <input type="button" id="downloadbutton" value="Save">
-            <input type="button" id="svgdownloadbutton" value="Save SVG">
-            <input type="file" id="fileupload" value="Load">
 
             <!-- MIDI Player -->
 

--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="no-js">
 
 <head>
     <meta charset="UTF-8">
@@ -19,9 +19,56 @@
     <script type="text/javascript" src="js/vendor/verovio-toolkit.js" defer></script>
     <script type="text/javascript" src="js/app.js" defer></script>
     <!-- <link rel="manifest" href="/site.webmanifest"> -->
+
+    <script>
+        document.documentElement.classList.replace('no-js', 'js');
+        document.documentElement.classList.add('loading');
+    </script>
 </head>
 
 <body>
+
+    <!-- Start screen -->
+
+    <div id="start-screen" class="start-screen">
+        <!-- @todo: add musical notes in the background in .start-screen__bg -->
+        <!-- <div class="start-screen__bg"></div> -->
+
+        <div class="start-screen__main">
+
+            <!-- Title -->
+            <h1 class="start-screen__title">MuseReduce</h1>
+
+            <!-- Loading -->
+            <div id="start-screen-loading-spinner" class="start-screen__loading">
+                <div class="loading-spinner">
+                    <div class="loading-spinner__disc"></div>
+                    <div class="loading-spinner__disc"></div>
+                    <div class="loading-spinner__disc"></div>
+                    <div class="loading-spinner__disc"></div>
+                    <div class="loading-spinner__disc"></div>
+                </div>
+                <p>Loading</p>
+            </div>
+
+            <!-- Pick a score -->
+            <p class="start-screen__instructions"><strong class="f500">Start by picking a <abbr title="Music Encoding Initiative">MEI</abbr> file on your device.</strong></p>
+            <label class="start-screen__filePicker file | btn btn--plain btn--big" for="start-screen-score-file-picker">
+                <span>
+                    Select a score
+                    <input class="file__input" id="start-screen-score-file-picker" type="file" accept=".mei">
+                </span>
+            </label>
+        </div>
+
+        <!-- About -->
+        <footer class="start-screen__footer">
+            <p>
+                MuseReduce is an <a href="https://github.com/DCMLab/reductive_analysis_app" target="_blank" rel="noopener" title="code repository">open-source</a> project
+                by the <a href="https://www.epfl.ch/labs/dcml" target="_blank" rel="noopener"><abbr title="Digital and Cognitive Musicology Lab">DCML</abbr></a>.
+            </p>
+        </footer>
+    </div>
 
     <!-- Filters used on the score (?) -->
 

--- a/public/index.html
+++ b/public/index.html
@@ -59,6 +59,10 @@
                     <input class="file__input" id="start-screen-score-file-picker" type="file" accept=".mei">
                 </span>
             </label>
+
+            <noscript>
+                <p>This app requires JavaScript to be enabled.</p>
+            </noscript>
         </div>
 
         <!-- About -->

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -314,47 +314,28 @@ export function savesvg() {
 }
 
 // Load a new MEI
-export function load() {
+export function load(event) {
   console.debug('Using globals: selected_extraselected, upload, reader, filenmae')
-  // var loaderModal = new jBox('Modal', {
-  //   id: 'loader-modal',
-  //   title: 'Loading...',
-  //   content: 'Please wait...',
-  //   closeOnEsc: false,
-  //   closeOnClick: false,
-  //   closeButton: false
-  // })
+
+  const files = event.target.files
 
   /* Cancel loading if changes are not saved? alert */
   selected = []
   extraselected = []
-  var upload = document.getElementById('score-file-picker')
-  if (upload.files.length == 1) {
+
+  if (files.length == 1) {
     reader.onload = function (e) {
       data = reader.result
-      // TODO: Understand why this setTimeout hack is necessary for the modal to appear.
-      setTimeout(() => {
-        // loaderModal.open()
-        setTimeout(() => {
-          load_finish(null)
-          // loaderModal.close(loaderModal)
-          music_tooltip_installer()
-          indicate_current_context()
-        }, 1000)
-      }, 1000)
+      load_finish(null)
+      music_tooltip_installer()
+      indicate_current_context()
     }
-    reader.readAsText(upload.files[0])
-    filename = upload.files[0].name.split('.').slice(0, -1).join('.')
+    reader.readAsText(files[0])
+    filename = files[0].name.split('.').slice(0, -1).join('.')
     if (filename == '')
-      filename = upload.files[0].name
-  } else {
-    // loaderModal.close()
-    return
+      filename = files[0].name
   }
 }
-
-const loadButton = document.getElementById('score-file-picker')
-loadButton.addEventListener('change', load)
 
 // Draw the existing graph
 export function draw_graph(draw_context) {

--- a/src/js/new/app.js
+++ b/src/js/new/app.js
@@ -14,8 +14,7 @@ class App {
   }
 
   init() {
-    doc.classList.remove('loading')
-    doc.classList.add('ready')
+    doc.classList.replace('loading', 'ready')
 
     this.viewport = viewport
 

--- a/src/js/new/events/index.js
+++ b/src/js/new/events/index.js
@@ -108,6 +108,7 @@ class EventsManager {
   onChange(e) {
     this.app.player?.onChange(e)
     this.app.ui?.filters?.onChange(e)
+    this.app.ui?.mainMenu?.onChange(e)
   }
 
   // Forms events

--- a/src/js/new/events/index.js
+++ b/src/js/new/events/index.js
@@ -109,6 +109,7 @@ class EventsManager {
     this.app.player?.onChange(e)
     this.app.ui?.filters?.onChange(e)
     this.app.ui?.mainMenu?.onChange(e)
+    this.app.ui?.startScreen?.onChange(e)
   }
 
   // Forms events
@@ -126,6 +127,11 @@ class EventsManager {
   onScoreLoad(e) {
     this.app.score?.onScoreLoad(e)
     this.app.ui?.onScoreLoad(e)
+
+    if (this.app.ui.startScreen) {
+      this.app.ui.startScreen.destroy()
+      delete this.app.ui.startScreen
+    }
   }
 
   onScoreSelection(e) {

--- a/src/js/new/modules/UI/MainMenu/index.js
+++ b/src/js/new/modules/UI/MainMenu/index.js
@@ -1,0 +1,44 @@
+/**
+ * @todo This main menu, the filters menu and the metadata menu have in common
+ * the same way to expand and collapse. It could be good to have a class in
+ * ordet to do that (e.g. CollapsibleFlyOut extending the FlyOut class).
+ */
+
+import { savesvg, save_orig } from '../../../../app'
+
+class MainMenu {
+  constructor() {
+    this.visible = false
+
+    // DOM elements
+    this.ctn = document.getElementById('main-menu')
+    this.toggleBtn = document.getElementById('main-menu-toggle')
+    this.selectFile = document.getElementById('score-file-picker')
+    this.saveFile = document.getElementById('save-file')
+    this.saveAsSvg = document.getElementById('save-file-svg')
+  }
+
+  onTap({ target }) {
+    if (target == this.toggleBtn) {
+      return this.toggle()
+    }
+
+    if (target == this.saveFile) {
+      return save_orig()
+    }
+
+    if (target == this.saveAsSvg) {
+      savesvg() // currently not working
+    }
+  }
+
+  toggle(state = !this.visible) {
+    this.visible = state
+    this.ctn.classList.toggle('fly-out--expanded', state)
+    this.ctn.classList.toggle('fly-out--collapsed', !state)
+  }
+}
+
+const mainMenu = new MainMenu()
+
+export default mainMenu

--- a/src/js/new/modules/UI/MainMenu/index.js
+++ b/src/js/new/modules/UI/MainMenu/index.js
@@ -4,7 +4,7 @@
  * ordet to do that (e.g. CollapsibleFlyOut extending the FlyOut class).
  */
 
-import { savesvg, save_orig } from '../../../../app'
+import { load, savesvg, save_orig } from '../../../../app'
 
 class MainMenu {
   constructor() {
@@ -13,7 +13,9 @@ class MainMenu {
     // DOM elements
     this.ctn = document.getElementById('main-menu')
     this.toggleBtn = document.getElementById('main-menu-toggle')
-    this.selectFile = document.getElementById('score-file-picker')
+
+    // File actions
+    this.filePicker = document.getElementById('score-file-picker')
     this.saveFile = document.getElementById('save-file')
     this.saveAsSvg = document.getElementById('save-file-svg')
   }
@@ -29,6 +31,13 @@ class MainMenu {
 
     if (target == this.saveAsSvg) {
       savesvg() // currently not working
+    }
+  }
+
+  onChange(e) {
+    if (e.composedPath().includes(this.filePicker)) {
+      load(e)
+      this.toggle(false)
     }
   }
 

--- a/src/js/new/modules/UI/StartScreen/index.js
+++ b/src/js/new/modules/UI/StartScreen/index.js
@@ -18,8 +18,10 @@ class StartScreen {
     }
   }
 
+  // Delete start screen HTML after fade-out.
   destroy() {
-    this.ctn.remove()
+    this.ctn.addEventListener('transitionend', this.ctn.remove, { once: true })
+    this.ctn.classList.add('start-screen--out')
   }
 }
 

--- a/src/js/new/modules/UI/StartScreen/index.js
+++ b/src/js/new/modules/UI/StartScreen/index.js
@@ -1,0 +1,28 @@
+import { load } from '../../../../app'
+
+class StartScreen {
+  constructor() {
+    this.ctn = document.getElementById('start-screen')
+    this.filePicker = document.getElementById('start-screen-score-file-picker')
+    this.init()
+  }
+
+  init() {
+    // Remove initial spinner from DOM.
+    document.getElementById('start-screen-loading-spinner').remove()
+  }
+
+  onChange(e) {
+    if (e.composedPath().includes(this.filePicker)) {
+      load(e)
+    }
+  }
+
+  destroy() {
+    this.ctn.remove()
+  }
+}
+
+const startScreen = new StartScreen()
+
+export default startScreen

--- a/src/js/new/modules/UI/index.js
+++ b/src/js/new/modules/UI/index.js
@@ -1,3 +1,4 @@
+import startScreen   from './StartScreen'
 import mainMenu   from './MainMenu'
 import filters    from './Filters'
 import metadata   from './Metadata'
@@ -63,6 +64,7 @@ class UI {
   }
 
   init() {
+    this.startScreen = startScreen
     this.mainMenu = mainMenu
     this.zoom = zoom
     this.selection = selection

--- a/src/js/new/modules/UI/index.js
+++ b/src/js/new/modules/UI/index.js
@@ -1,3 +1,4 @@
+import mainMenu   from './MainMenu'
 import filters    from './Filters'
 import metadata   from './Metadata'
 import navigation from './Navigation'
@@ -17,6 +18,7 @@ class UI {
 
     if (!e.composedPath().includes(this.ctn)) { return }
 
+    this.mainMenu?.onTap(e)
     this.zoom?.onTap(e)
     this.selection?.onTap(e)
     this.metadata?.onTap(e)
@@ -61,6 +63,7 @@ class UI {
   }
 
   init() {
+    this.mainMenu = mainMenu
     this.zoom = zoom
     this.selection = selection
     this.navigation = navigation

--- a/src/js/new/utils/file.js
+++ b/src/js/new/utils/file.js
@@ -1,0 +1,29 @@
+/**
+ * Trigger a file download
+ * https://pqina.nl/blog/how-to-prompt-the-user-to-download-a-file-instead-of-navigating-to-it
+ *
+ * When browsers support evolves, it could use the FileSystem API:
+ * https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
+ * https://web.dev/file-system-access/
+ *
+ * @param {*} filedata
+ * @param {string} filename
+ * @param {string} mimeType
+ */
+export function downloadAs(filedata, filename, mimeType) {
+  const file = new Blob([filedata], { type: mimeType })
+
+  const link = document.createElement('a')
+  link.classList.add('none')
+  link.href = URL.createObjectURL(file)
+  link.download = filename
+
+  document.body.appendChild(link)
+  link.click()
+
+  // timeout apparently needed on Firefox
+  setTimeout(() => {
+    URL.revokeObjectURL(link.href)
+    link.remove()
+  }, 0)
+}

--- a/src/js/new/utils/file.js
+++ b/src/js/new/utils/file.js
@@ -14,7 +14,7 @@ export function downloadAs(filedata, filename, mimeType) {
   const file = new Blob([filedata], { type: mimeType })
 
   const link = document.createElement('a')
-  link.classList.add('none')
+  link.style.display = 'none'
   link.href = URL.createObjectURL(file)
   link.download = filename
 

--- a/src/other-css/style.css
+++ b/src/other-css/style.css
@@ -81,7 +81,7 @@ body {
   position: sticky;
   width: fit-content;
   width: -moz-fit-content;
-  top: 0;
+  top: 200px;
   left: 0;
   padding-bottom: 0.3rem;
   padding-top: 0.3rem;

--- a/src/other-css/style.css
+++ b/src/other-css/style.css
@@ -670,7 +670,7 @@ body:not(.mousedown) #relations_panel_toggle:hover {
     right: 10;
     width: 100px;
     height: 100%;
-    z-index: 100;
+    z-index: 90;
 }
 
 .bookmark {

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -201,7 +201,6 @@ abbr[title] {
 
 a {
   color: v(primary);
-  text-decoration: none;
 
   * { pointer-events: none; }
 }

--- a/src/sass/app.scss
+++ b/src/sass/app.scss
@@ -1,8 +1,8 @@
 // Abstract (mixins and functions)
-@import '~family.scss';
-@import '~hsl.scss';
-@import '~v.scss';
-@import '~double-dash.scss';
+@import 'family.scss';
+@import 'hsl.scss';
+@import 'v.scss';
+@import 'double-dash.scss';
 @import 'abstract/abstract';
 
 // Variables
@@ -15,6 +15,9 @@
 
 // @keyframes
 @import 'animations/animations';
+
+// Typo
+@import 'typo/typo';
 
 // Utility
 @import 'utility/utility';
@@ -30,3 +33,4 @@
 
 // Pages
 @import 'layout/layout';
+@import 'pages/start-screen';

--- a/src/sass/components/btn/_base.scss
+++ b/src/sass/components/btn/_base.scss
@@ -57,6 +57,10 @@
   }
 }
 
+.btn--big {
+  padding: 1.7rem 2.5rem;
+}
+
 .btn--small {
   padding: .8rem;
 }

--- a/src/sass/components/components.scss
+++ b/src/sass/components/components.scss
@@ -1,3 +1,4 @@
+@import 'loading/loading';
 @import 'btn/btn';
 @import 'notch/notch';
 @import 'fly-out/fly-out';

--- a/src/sass/components/fly-out/_collapsible.scss
+++ b/src/sass/components/fly-out/_collapsible.scss
@@ -7,7 +7,8 @@
 
   padding-block-end: 0;
 
-  > :not(.fly-out__toggle) {
+  > :not(.fly-out__toggle),
+  .fly-out__hideIfCollapsed {
     display: none;
   }
 
@@ -24,6 +25,10 @@
     .btn__icon {
       transform: rotate(180deg);
     }
+  }
+
+  .fly-out__hideIfExpanded {
+    display: none;
   }
 }
 

--- a/src/sass/components/loading/loading.scss
+++ b/src/sass/components/loading/loading.scss
@@ -1,0 +1,58 @@
+@keyframes loading-spinner {
+  100% { transform: rotate(1turn); }
+}
+
+@keyframes loading-disc {
+  80% { transform: rotate(1turn); }
+  100% { transform: rotate(1turn); }
+}
+
+// Container of the spinner bullets
+
+.loading-spinner {
+  --spinner-size: 6rem;
+  --spinner-bullet-diameter: 1.4rem;
+
+  size: v(spinner-size);
+
+  position: relative;
+
+  animation: loading-spinner 19s infinite linear;
+
+  @media (--no-motion) {
+    display: none;
+  }
+}
+
+// Spinner bullet
+
+.loading-spinner__disc {
+
+  // size is {10% * bullet index} smaller (compared to the biggest one)
+  --spinner-bullet-size: calc(
+    var(--spinner-bullet-diameter)
+    * (1 - var(--spinner-bullet-index) * .1)
+  );
+  size: v(spinner-bullet-size);
+
+  position: absolute;
+  top: calc((var(--spinner-bullet-diameter) - var(--spinner-bullet-size)) / 2);
+  left: calc(50% - var(--spinner-bullet-size) / 2);
+  // `calc` 👆 adjust bullets position so they all share the same center.
+
+  background: v(primary);
+  border-radius: 50%;
+
+  opacity: calc(1 - var(--spinner-bullet-index) * .16); // from 1 to 0.3
+
+  transform-origin: 50% calc(var(--spinner-size) / 2);
+
+  animation: loading-disc 3.5s infinite $in-out-quart calc(var(--spinner-bullet-index) * .17s);
+
+  // Bullet index used for staggering of animation delay, opacity and size.
+  @for $bullet-index from 1 through 5 {
+    &:nth-of-type(#{$bullet-index}) {
+      --spinner-bullet-index: #{$bullet-index - 1};
+    }
+  }
+}

--- a/src/sass/layout/_menu-and-filters.scss
+++ b/src/sass/layout/_menu-and-filters.scss
@@ -3,3 +3,7 @@
   grid-template-columns: auto auto;
   gap: 1.5rem;
 }
+
+.fly-out--main-menu {
+  max-width: 25.8rem;
+}

--- a/src/sass/layout/ui/_relations.scss
+++ b/src/sass/layout/ui/_relations.scss
@@ -1,5 +1,5 @@
 .fly-out--relations {
-  max-width: 37rem; // shouldn’t exist when not expanded
+  max-width: 37rem;
 
   position: fixed;
   z-index: 1;

--- a/src/sass/pages/_start-screen.scss
+++ b/src/sass/pages/_start-screen.scss
@@ -34,6 +34,11 @@
   }
 }
 
+.start-screen--out {
+  opacity: 0;
+  transition: opacity .3s $in-quad;
+}
+
 // Title, instructions, file picker
 
 .start-screen__main {

--- a/src/sass/pages/_start-screen.scss
+++ b/src/sass/pages/_start-screen.scss
@@ -1,0 +1,84 @@
+// 688px * 640px
+@custom-media --start-screen-more-padding (width > 43em) and (height > 40em);
+
+// Container
+
+.start-screen {
+  position: fixed;
+  z-index: 99;
+  inset: 0;
+
+  --start-screen-padding: 2rem;
+  padding: v(start-screen-padding);
+
+  display: grid;
+  grid-template-rows: 1fr auto;
+  place-items: center;
+
+  overflow: auto;
+
+  text-align: center;
+  font-size: 1.6rem;
+
+  background: v(bg);
+
+  @supports (top: #{'max(0px)'}) {
+    padding: #{'max(var(--safe-top), var(--start-screen-padding))'}
+      #{'max(var(--safe-right), var(--start-screen-padding))'}
+      #{'max(var(--safe-bottom), var(--start-screen-padding))'}
+      #{'max(var(--safe-left), var(--start-screen-padding))'};
+  }
+
+  @media (--start-screen-more-padding) {
+    --start-screen-padding: 5rem;
+  }
+}
+
+// Title, instructions, file picker
+
+.start-screen__main {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.start-screen__title {
+  font-size: 3.6rem;
+  font-weight: 600;
+}
+
+.start-screen__loading {
+  position: absolute;
+
+  html:not(.loading) & {
+    display: none;
+  }
+}
+
+.start-screen__instructions {
+  html:not(.ready) & {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+
+.start-screen__filePicker {
+  margin-top: 6rem;
+
+  transition:
+    opacity .2s $in-out-quad .1s,
+    transform .3s $out-back .1s;
+
+  html:not(.ready) & {
+    opacity: 0;
+    transform: scale(.95);
+    visibility: hidden;
+  }
+}
+
+// Footer (about)
+
+.start-screen__footer {
+  margin-top: 7rem;
+}

--- a/src/sass/typo/_sizes.scss
+++ b/src/sass/typo/_sizes.scss
@@ -1,3 +1,3 @@
-.fs100p {
-  font-size: 100%;
-}
+// .fs100p {
+//   font-size: 100%;
+// }

--- a/src/sass/typo/_titles.scss
+++ b/src/sass/typo/_titles.scss
@@ -1,9 +1,9 @@
-.h1 {
-  font-weight: 400;
-  font-size: 2.4rem;
-  line-height: 1.333;
+// .h1 {
+//   font-weight: 400;
+//   font-size: 2.4rem;
+//   line-height: 1.333;
 
-  @media (--tablet-7) {
-    font-size: 4rem;
-  }
-}
+//   @media (--tablet-7) {
+//     font-size: 4rem;
+//   }
+// }

--- a/src/sass/typo/_weight.scss
+++ b/src/sass/typo/_weight.scss
@@ -1,3 +1,3 @@
-.f400 {
-  font-weight: 400;
+.f500 {
+  font-weight: 500;
 }


### PR DESCRIPTION
This PR is related to #148 but shouldn’t close it (it doesn’t include the settings).

It:
- moves the file actions in the new main menu;
- adds a start screen with a loading spinner displayed while the JS is loading;
- adds a message when JavaScript isn’t available;
