### PR TITLE
Fix reversed primary and secondary selection in tooltip

### DIFF
--- a/src/js/new/modules/UI/Selection/legend.js
+++ b/src/js/new/modules/UI/Selection/legend.js
@@ -25,8 +25,8 @@ export default class SelectionLegend extends FlyOut {
 
     if (this.visible) {
       this.updateTitle()
-      this.updateRow('primary', selected)
-      this.updateRow('secondary', extraselected)
+      this.updateRow('primary', extraselected)
+      this.updateRow('secondary', selected)
     }
   }
 


### PR DESCRIPTION
Closes #171. @pettter If I’m correct, this should do the trick.