### PR TITLE
Add toggle for selection mode (primary, secondary)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,9 +69,9 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.0.tgz",
-      "integrity": "sha512-WLrM42vKX/4atIoQB+eb0ovUof53UUvecb4qGjU2PDDWRiZr50ZpiV8NpcLo7iSxeGYrRG0Mqembsa+UrTAV6Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.7.tgz",
+      "integrity": "sha512-0iBF+G2Qml0y3mY5dirolyToLSR88a/KB6F2Gm8J/lOnyL8wbEOHak0DHF8gjc9XZGgTDGv/jYXNiapvsYyHTA==",
       "dev": true,
       "dependencies": {
         "commander": "^4.0.1",
@@ -98,12 +98,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
       "dev": true,
       "dependencies": {
-        "@babel/highlight": "^7.16.0"
+        "@babel/highlight": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -119,20 +119,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.5.tgz",
-      "integrity": "sha512-wUcenlLzuWMZ9Zt8S0KmFwGlH6QKRh3vsm/dhDA3CHkiTA45YuG1XkHRcNRl73EFPXDp/d5kVOU0/y7x2w6OaQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
+      "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.5",
-        "@babel/helper-compilation-targets": "^7.16.3",
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helpers": "^7.16.5",
-        "@babel/parser": "^7.16.5",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helpers": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -167,12 +167,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.5.tgz",
-      "integrity": "sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.7.tgz",
+      "integrity": "sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.16.7",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       },
@@ -181,38 +181,38 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
-      "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.5.tgz",
-      "integrity": "sha512-3JEA9G5dmmnIWdzaT9d0NmFRgYnWUThLsDaL7982H0XqqWr56lRrsmwheXFMjR+TMl7QMBb6mzy9kvgr1lRLUA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
+      "integrity": "sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-explode-assignable-expression": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-explode-assignable-expression": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
-      "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.16.0",
-        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       },
@@ -224,18 +224,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.5.tgz",
-      "integrity": "sha512-NEohnYA7mkB8L5JhU7BLwcBdU3j83IziR9aseMueWGeAjblbul3zzb8UvJ3a1zuBiqCMObzCJHFqKIQE6hTVmg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz",
+      "integrity": "sha512-kIFozAvVfK05DM4EVQYKK+zteWvY85BFdGBRQBytRyY3y+6PX0DkDOn/CZ3lEuczCfrCxEzwt0YtP/87YPTWSw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-member-expression-to-functions": "^7.16.5",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/helper-replace-supers": "^7.16.5",
-        "@babel/helper-split-export-declaration": "^7.16.0"
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-member-expression-to-functions": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -245,12 +245,12 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.0.tgz",
-      "integrity": "sha512-3DyG0zAFAZKcOp7aVr33ddwkxJ0Z0Jr5V99y3I690eYLpukJsJvAbzTy1ewoCqsML8SbIrjH14Jc/nSQ4TvNPA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz",
+      "integrity": "sha512-fk5A6ymfp+O5+p2yCkXAu5Kyj6v0xh0RBeNcAkYUMDvvAAoxvSKXn+Jb37t/yWFiQVDFK1ELpUTD8/aLhCPu+g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.16.7",
         "regexpu-core": "^4.7.1"
       },
       "engines": {
@@ -280,168 +280,168 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.5.tgz",
-      "integrity": "sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-explode-assignable-expression": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz",
-      "integrity": "sha512-Hk2SLxC9ZbcOhLpg/yMznzJ11W++lg5GMbxt1ev6TXUiJB0N42KPC+7w8a+eWGuqDnUYuwStJoZHM7RgmIOaGQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz",
+      "integrity": "sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.5.tgz",
-      "integrity": "sha512-7fecSXq7ZrLE+TWshbGT+HyCLkxloWNhTbU2QM1NTI/tDqyf0oZiMcEfYtDuUDCo528EOlt39G1rftea4bRZIw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
+      "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.5.tgz",
-      "integrity": "sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-simple-access": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-      "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
+      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
-      "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.5.tgz",
-      "integrity": "sha512-X+aAJldyxrOmN9v3FKp+Hu1NO69VWgYgDGq6YDykwRPzxs5f2N+X988CBXS7EQahDU+Vpet5QYMqLk+nsp+Qxw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.7.tgz",
+      "integrity": "sha512-C3o117GnP/j/N2OWo+oepeWbFEKRfNaay+F1Eo5Mj3A1SRjyx+qaFhm23nlipub7Cjv2azdUUiDH+VlpdwUFRg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-wrap-function": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-wrap-function": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.5.tgz",
-      "integrity": "sha512-ao3seGVa/FZCMCCNDuBcqnBFSbdr8N2EW35mzojx3TwfIbdPmNK+JV6+2d5bR0Z71W5ocLnQp9en/cTF7pBJiQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
+      "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-member-expression-to-functions": "^7.16.5",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-member-expression-to-functions": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
-      "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -460,71 +460,71 @@
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.5.tgz",
-      "integrity": "sha512-2J2pmLBqUqVdJw78U0KPNdeE2qeuIyKoG4mKV7wAq3mc4jJG282UgjZw4ZYDnqiWQuS3Y3IYdF/AQ6CpyBV3VA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.7.tgz",
+      "integrity": "sha512-7a9sABeVwcunnztZZ7WTgSw6jVYLzM1wua0Z4HIXm9S3/HC96WKQTkFgGEaj5W06SHHihPJ6Le6HzS5cGOQMNw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.5.tgz",
-      "integrity": "sha512-TLgi6Lh71vvMZGEkFuIxzaPsyeYCHQ5jJOOX1f0xXn0uciFuE8cEk0wyBquMcCxBXZ5BJhE2aUB7pnWTD150Tw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
+      "integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
       "dev": true,
       "dependencies": {
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -533,9 +533,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.5.tgz",
-      "integrity": "sha512-+Ce7T5iPNWzfu9C1aB5tN3Lyafs5xb3Ic7vBWyZL2KXT3QSdD1dD3CvgOzPmQKoNNRt6uauc0XwNJTQtXC2/Mw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.7.tgz",
+      "integrity": "sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -545,12 +545,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.2.tgz",
-      "integrity": "sha512-h37CvpLSf8gb2lIJ2CgC3t+EjFbi0t8qS7LCS1xcJIlEXE4czlofwaW7W1HA8zpgOCzI9C1nmoqNR1zWkk0pQg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz",
+      "integrity": "sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -560,14 +560,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.0.tgz",
-      "integrity": "sha512-4tcFwwicpWTrpl9qjf7UsoosaArgImF85AxqCRZlgc3IQDvkUHjJpruXAL58Wmj+T6fypWTC/BakfEkwIL/pwA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz",
+      "integrity": "sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.16.0"
+        "@babel/plugin-proposal-optional-chaining": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -577,13 +577,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.5.tgz",
-      "integrity": "sha512-C/FX+3HNLV6sz7AqbTQqEo1L9/kfrKjxcVtgyBCmvIgOjvuBVUWooDoi7trsLxOzCEo5FccjRvKHkfDsJFZlfA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.7.tgz",
+      "integrity": "sha512-TTXBT3A5c11eqRzaC6beO6rlFT3Mo9C2e8eB44tTr52ESXSK2CIc2fOp1ynpAwQA8HhBMho+WXhMHWlAe3xkpw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-remap-async-to-generator": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-remap-async-to-generator": "^7.16.7",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       },
       "engines": {
@@ -594,13 +594,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.5.tgz",
-      "integrity": "sha512-pJD3HjgRv83s5dv1sTnDbZOaTjghKEz8KUn1Kbh2eAIRhGuyQ1XSeI4xVXU3UlIEVA3DAyIdxqT1eRn7Wcn55A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
+      "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -610,13 +610,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-static-block": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.5.tgz",
-      "integrity": "sha512-EEFzuLZcm/rNJ8Q5krK+FRKdVkd6FjfzT9tuSZql9sQn64K0hHA2KLJ0DqVot9/iV6+SsuadC5yI39zWnm+nmQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.7.tgz",
+      "integrity": "sha512-dgqJJrcZoG/4CkMopzhPJjGxsIe9A8RlkQLnL/Vhhx8AA9ZuaRwGSlscSh42hazc7WSrya/IK7mTeoF0DP9tEw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       },
       "engines": {
@@ -627,12 +627,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.5.tgz",
-      "integrity": "sha512-P05/SJZTTvHz79LNYTF8ff5xXge0kk5sIIWAypcWgX4BTRUgyHc8wRxJ/Hk+mU0KXldgOOslKaeqnhthcDJCJQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
+      "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       },
       "engines": {
@@ -643,12 +643,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.5.tgz",
-      "integrity": "sha512-i+sltzEShH1vsVydvNaTRsgvq2vZsfyrd7K7vPLUU/KgS0D5yZMe6uipM0+izminnkKrEfdUnz7CxMRb6oHZWw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz",
+      "integrity": "sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
       },
       "engines": {
@@ -659,12 +659,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.5.tgz",
-      "integrity": "sha512-QQJueTFa0y9E4qHANqIvMsuxM/qcLQmKttBACtPCQzGUEizsXDACGonlPiSwynHfOa3vNw0FPMVvQzbuXwh4SQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz",
+      "integrity": "sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
       },
       "engines": {
@@ -675,12 +675,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.5.tgz",
-      "integrity": "sha512-xqibl7ISO2vjuQM+MzR3rkd0zfNWltk7n9QhaD8ghMmMceVguYrNDt7MikRyj4J4v3QehpnrU8RYLnC7z/gZLA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
+      "integrity": "sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       },
       "engines": {
@@ -691,12 +691,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.5.tgz",
-      "integrity": "sha512-YwMsTp/oOviSBhrjwi0vzCUycseCYwoXnLiXIL3YNjHSMBHicGTz7GjVU/IGgz4DtOEXBdCNG72pvCX22ehfqg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
+      "integrity": "sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       },
       "engines": {
@@ -707,12 +707,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-numeric-separator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.5.tgz",
-      "integrity": "sha512-DvB9l/TcsCRvsIV9v4jxR/jVP45cslTVC0PMVHvaJhhNuhn2Y1SOhCSFlPK777qLB5wb8rVDaNoqMTyOqtY5Iw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
+      "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       },
       "engines": {
@@ -723,16 +723,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.5.tgz",
-      "integrity": "sha512-UEd6KpChoyPhCoE840KRHOlGhEZFutdPDMGj+0I56yuTTOaT51GzmnEl/0uT41fB/vD2nT+Pci2KjezyE3HmUw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.7.tgz",
+      "integrity": "sha512-3O0Y4+dw94HA86qSg9IHfyPktgR7q3gpNVAeiKQd+8jBKFaU5NQS1Yatgo4wY+UFNuLjvxcSmzcsHqrhgTyBUA==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.16.4",
-        "@babel/helper-compilation-targets": "^7.16.3",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.16.5"
+        "@babel/plugin-transform-parameters": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -742,12 +742,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.5.tgz",
-      "integrity": "sha512-ihCMxY1Iljmx4bWy/PIMJGXN4NS4oUj1MKynwO07kiKms23pNvIn1DMB92DNB2R0EA882sw0VXIelYGdtF7xEQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz",
+      "integrity": "sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       },
       "engines": {
@@ -758,12 +758,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.5.tgz",
-      "integrity": "sha512-kzdHgnaXRonttiTfKYnSVafbWngPPr2qKw9BWYBESl91W54e+9R5pP70LtWxV56g0f05f/SQrwHYkfvbwcdQ/A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz",
+      "integrity": "sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
@@ -775,13 +775,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.5.tgz",
-      "integrity": "sha512-+yFMO4BGT3sgzXo+lrq7orX5mAZt57DwUK6seqII6AcJnJOIhBJ8pzKH47/ql/d426uQ7YhN8DpUFirQzqYSUA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.7.tgz",
+      "integrity": "sha512-7twV3pzhrRxSwHeIvFE6coPgvo+exNDOiGUMg39o2LiLo1Y+4aKpfkcLGcg1UHonzorCt7SNXnoMyCnnIOA8Sw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -791,14 +791,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.5.tgz",
-      "integrity": "sha512-+YGh5Wbw0NH3y/E5YMu6ci5qTDmAEVNoZ3I54aB6nVEOZ5BQ7QJlwKq5pYVucQilMByGn/bvX0af+uNaPRCabA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz",
+      "integrity": "sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       },
       "engines": {
@@ -809,13 +809,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.5.tgz",
-      "integrity": "sha512-s5sKtlKQyFSatt781HQwv1hoM5BQ9qRH30r+dK56OLDsHmV74mzwJNX7R1yMuE7VZKG5O6q/gmOGSAO6ikTudg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz",
+      "integrity": "sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=4"
@@ -1026,12 +1026,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.5.tgz",
-      "integrity": "sha512-8bTHiiZyMOyfZFULjsCnYOWG059FVMes0iljEHSfARhNgFfpsqE92OrCffv3veSw9rwMkYcFe9bj0ZoXU2IGtQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
+      "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1041,14 +1041,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.5.tgz",
-      "integrity": "sha512-TMXgfioJnkXU+XRoj7P2ED7rUm5jbnDWwlCuFVTpQboMfbSya5WrmubNBAMlk7KXvywpo8rd8WuYZkis1o2H8w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.7.tgz",
+      "integrity": "sha512-pFEfjnK4DfXCfAlA5I98BYdDJD8NltMzx19gt6DAmfE+2lXRfPUoa0/5SUjT4+TDE1W/rcxU/1lgN55vpAjjdg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-remap-async-to-generator": "^7.16.5"
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-remap-async-to-generator": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1058,12 +1058,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.5.tgz",
-      "integrity": "sha512-BxmIyKLjUGksJ99+hJyL/HIxLIGnLKtw772zYDER7UuycDZ+Xvzs98ZQw6NGgM2ss4/hlFAaGiZmMNKvValEjw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
+      "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1073,12 +1073,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.5.tgz",
-      "integrity": "sha512-JxjSPNZSiOtmxjX7PBRBeRJTUKTyJ607YUYeT0QJCNdsedOe+/rXITjP08eG8xUpsLfPirgzdCFN+h0w6RI+pQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
+      "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1088,18 +1088,18 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.5.tgz",
-      "integrity": "sha512-DzJ1vYf/7TaCYy57J3SJ9rV+JEuvmlnvvyvYKFbk5u46oQbBvuB9/0w+YsVsxkOv8zVWKpDmUoj4T5ILHoXevA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
+      "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-replace-supers": "^7.16.5",
-        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1110,12 +1110,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.5.tgz",
-      "integrity": "sha512-n1+O7xtU5lSLraRzX88CNcpl7vtGdPakKzww74bVwpAIRgz9JVLJJpOLb0uYqcOaXVM0TL6X0RVeIJGD2CnCkg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
+      "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1125,12 +1125,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.5.tgz",
-      "integrity": "sha512-GuRVAsjq+c9YPK6NeTkRLWyQskDC099XkBSVO+6QzbnOnH2d/4mBVXYStaPrZD3dFRfg00I6BFJ9Atsjfs8mlg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.7.tgz",
+      "integrity": "sha512-VqAwhTHBnu5xBVDCvrvqJbtLUa++qZaWC0Fgr2mqokBlulZARGyIvZDoqbPlPaKImQ9dKAcCzbv+ul//uqu70A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1140,13 +1140,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.5.tgz",
-      "integrity": "sha512-iQiEMt8Q4/5aRGHpGVK2Zc7a6mx7qEAO7qehgSug3SDImnuMzgmm/wtJALXaz25zUj1PmnNHtShjFgk4PDx4nw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz",
+      "integrity": "sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1156,12 +1156,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.5.tgz",
-      "integrity": "sha512-81tijpDg2a6I1Yhj4aWY1l3O1J4Cg/Pd7LfvuaH2VVInAkXtzibz9+zSPdUM1WvuUi128ksstAP0hM5w48vQgg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz",
+      "integrity": "sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1171,13 +1171,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.5.tgz",
-      "integrity": "sha512-12rba2HwemQPa7BLIKCzm1pT2/RuQHtSFHdNl41cFiC6oi4tcrp7gjB07pxQvFpcADojQywSjblQth6gJyE6CA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz",
+      "integrity": "sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1187,12 +1187,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.5.tgz",
-      "integrity": "sha512-+DpCAJFPAvViR17PIMi9x2AE34dll5wNlXO43wagAX2YcRGgEVHCNFC4azG85b4YyyFarvkc/iD5NPrz4Oneqw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
+      "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1202,13 +1202,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.5.tgz",
-      "integrity": "sha512-Fuec/KPSpVLbGo6z1RPw4EE1X+z9gZk1uQmnYy7v4xr4TO9p41v1AoUuXEtyqAI7H+xNJYSICzRqZBhDEkd3kQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
+      "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1218,12 +1219,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.5.tgz",
-      "integrity": "sha512-B1j9C/IfvshnPcklsc93AVLTrNVa69iSqztylZH6qnmiAsDDOmmjEYqOm3Ts2lGSgTSywnBNiqC949VdD0/gfw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
+      "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1233,12 +1234,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.5.tgz",
-      "integrity": "sha512-d57i3vPHWgIde/9Y8W/xSFUndhvhZN5Wu2TjRrN1MVz5KzdUihKnfDVlfP1U7mS5DNj/WHHhaE4/tTi4hIyHwQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
+      "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1248,13 +1249,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.5.tgz",
-      "integrity": "sha512-oHI15S/hdJuSCfnwIz+4lm6wu/wBn7oJ8+QrkzPPwSFGXk8kgdI/AIKcbR/XnD1nQVMg/i6eNaXpszbGuwYDRQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz",
+      "integrity": "sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       },
       "engines": {
@@ -1265,14 +1266,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.5.tgz",
-      "integrity": "sha512-ABhUkxvoQyqhCWyb8xXtfwqNMJD7tx+irIRnUh6lmyFud7Jln1WzONXKlax1fg/ey178EXbs4bSGNd6PngO+SQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.7.tgz",
+      "integrity": "sha512-h2RP2kE7He1ZWKyAlanMZrAbdv+Acw1pA8dQZhE025WJZE2z0xzFADAinXA9fxd5bn7JnM+SdOGcndGx1ARs9w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-simple-access": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       },
       "engines": {
@@ -1283,15 +1284,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.5.tgz",
-      "integrity": "sha512-53gmLdScNN28XpjEVIm7LbWnD/b/TpbwKbLk6KV4KqC9WyU6rq1jnNmVG6UgAdQZVVGZVoik3DqHNxk4/EvrjA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
+      "integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       },
       "engines": {
@@ -1302,13 +1303,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.5.tgz",
-      "integrity": "sha512-qTFnpxHMoenNHkS3VoWRdwrcJ3FhX567GvDA3hRZKF0Dj8Fmg0UzySZp3AP2mShl/bzcywb/UWAMQIjA1bhXvw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz",
+      "integrity": "sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1318,12 +1319,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.5.tgz",
-      "integrity": "sha512-/wqGDgvFUeKELW6ex6QB7dLVRkd5ehjw34tpXu1nhKC0sFfmaLabIswnpf8JgDyV2NeDmZiwoOb0rAmxciNfjA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.7.tgz",
+      "integrity": "sha512-kFy35VwmwIQwCjwrAQhl3+c/kr292i4KdLPKp5lPH03Ltc51qnFlIADoyPxc/6Naz3ok3WdYKg+KK6AH+D4utg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1333,12 +1334,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.5.tgz",
-      "integrity": "sha512-ZaIrnXF08ZC8jnKR4/5g7YakGVL6go6V9ql6Jl3ecO8PQaQqFE74CuM384kezju7Z9nGCCA20BqZaR1tJ/WvHg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz",
+      "integrity": "sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1348,13 +1349,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.5.tgz",
-      "integrity": "sha512-tded+yZEXuxt9Jdtkc1RraW1zMF/GalVxaVVxh41IYwirdRgyAxxxCKZ9XB7LxZqmsjfjALxupNE1MIz9KH+Zg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
+      "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-replace-supers": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1364,12 +1365,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.5.tgz",
-      "integrity": "sha512-B3O6AL5oPop1jAVg8CV+haeUte9oFuY85zu0jwnRNZZi3tVAbJriu5tag/oaO2kGaQM/7q7aGPBlTI5/sr9enA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
+      "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1379,12 +1380,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.5.tgz",
-      "integrity": "sha512-+IRcVW71VdF9pEH/2R/Apab4a19LVvdVsr/gEeotH00vSDVlKD+XgfSIw+cgGWsjDB/ziqGv/pGoQZBIiQVXHg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
+      "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1394,9 +1395,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.5.tgz",
-      "integrity": "sha512-2z+it2eVWU8TtQQRauvGUqZwLy4+7rTfo6wO4npr+fvvN1SW30ZF3O/ZRCNmTuu4F5MIP8OJhXAhRV5QMJOuYg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
+      "integrity": "sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==",
       "dev": true,
       "dependencies": {
         "regenerator-transform": "^0.14.2"
@@ -1409,12 +1410,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.5.tgz",
-      "integrity": "sha512-aIB16u8lNcf7drkhXJRoggOxSTUAuihTSTfAcpynowGJOZiGf+Yvi7RuTwFzVYSYPmWyARsPqUGoZWWWxLiknw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz",
+      "integrity": "sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1424,12 +1425,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.5.tgz",
-      "integrity": "sha512-ZbuWVcY+MAXJuuW7qDoCwoxDUNClfZxoo7/4swVbOW1s/qYLOMHlm9YRWMsxMFuLs44eXsv4op1vAaBaBaDMVg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
+      "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1439,12 +1440,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.5.tgz",
-      "integrity": "sha512-5d6l/cnG7Lw4tGHEoga4xSkYp1euP7LAtrah1h1PgJ3JY7yNsjybsxQAnVK4JbtReZ/8z6ASVmd3QhYYKLaKZw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
+      "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
       },
       "engines": {
@@ -1455,12 +1456,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.5.tgz",
-      "integrity": "sha512-usYsuO1ID2LXxzuUxifgWtJemP7wL2uZtyrTVM4PKqsmJycdS4U4mGovL5xXkfUheds10Dd2PjoQLXw6zCsCbg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz",
+      "integrity": "sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1470,12 +1471,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.5.tgz",
-      "integrity": "sha512-gnyKy9RyFhkovex4BjKWL3BVYzUDG6zC0gba7VMLbQoDuqMfJ1SDXs8k/XK41Mmt1Hyp4qNAvGFb9hKzdCqBRQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
+      "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1485,12 +1486,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.5.tgz",
-      "integrity": "sha512-ldxCkW180qbrvyCVDzAUZqB0TAeF8W/vGJoRcaf75awm6By+PxfJKvuqVAnq8N9wz5Xa6mSpM19OfVKKVmGHSQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz",
+      "integrity": "sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1500,12 +1501,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.5.tgz",
-      "integrity": "sha512-shiCBHTIIChGLdyojsKQjoAyB8MBwat25lKM7MJjbe1hE0bgIppD+LX9afr41lLHOhqceqeWl4FkLp+Bgn9o1Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
+      "integrity": "sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1515,13 +1516,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.5.tgz",
-      "integrity": "sha512-GTJ4IW012tiPEMMubd7sD07iU9O/LOo8Q/oU4xNhcaq0Xn8+6TcUQaHtC8YxySo1T+ErQ8RaWogIEeFhKGNPzw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz",
+      "integrity": "sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1531,32 +1532,32 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.5.tgz",
-      "integrity": "sha512-MiJJW5pwsktG61NDxpZ4oJ1CKxM1ncam9bzRtx9g40/WkLRkxFP6mhpkYV0/DxcciqoiHicx291+eUQrXb/SfQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.7.tgz",
+      "integrity": "sha512-urX3Cee4aOZbRWOSa3mKPk0aqDikfILuo+C7qq7HY0InylGNZ1fekq9jmlr3pLWwZHF4yD7heQooc2Pow2KMyQ==",
       "dev": true,
       "dependencies": {
         "@babel/compat-data": "^7.16.4",
-        "@babel/helper-compilation-targets": "^7.16.3",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.2",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.16.5",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-class-static-block": "^7.16.5",
-        "@babel/plugin-proposal-dynamic-import": "^7.16.5",
-        "@babel/plugin-proposal-export-namespace-from": "^7.16.5",
-        "@babel/plugin-proposal-json-strings": "^7.16.5",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.16.5",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.5",
-        "@babel/plugin-proposal-numeric-separator": "^7.16.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.16.5",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.16.5",
-        "@babel/plugin-proposal-optional-chaining": "^7.16.5",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.16.5",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-validator-option": "^7.16.7",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.7",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.7",
+        "@babel/plugin-proposal-async-generator-functions": "^7.16.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.7",
+        "@babel/plugin-proposal-class-static-block": "^7.16.7",
+        "@babel/plugin-proposal-dynamic-import": "^7.16.7",
+        "@babel/plugin-proposal-export-namespace-from": "^7.16.7",
+        "@babel/plugin-proposal-json-strings": "^7.16.7",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.16.7",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
+        "@babel/plugin-proposal-numeric-separator": "^7.16.7",
+        "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.7",
+        "@babel/plugin-proposal-private-methods": "^7.16.7",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
@@ -1571,40 +1572,40 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.16.5",
-        "@babel/plugin-transform-async-to-generator": "^7.16.5",
-        "@babel/plugin-transform-block-scoped-functions": "^7.16.5",
-        "@babel/plugin-transform-block-scoping": "^7.16.5",
-        "@babel/plugin-transform-classes": "^7.16.5",
-        "@babel/plugin-transform-computed-properties": "^7.16.5",
-        "@babel/plugin-transform-destructuring": "^7.16.5",
-        "@babel/plugin-transform-dotall-regex": "^7.16.5",
-        "@babel/plugin-transform-duplicate-keys": "^7.16.5",
-        "@babel/plugin-transform-exponentiation-operator": "^7.16.5",
-        "@babel/plugin-transform-for-of": "^7.16.5",
-        "@babel/plugin-transform-function-name": "^7.16.5",
-        "@babel/plugin-transform-literals": "^7.16.5",
-        "@babel/plugin-transform-member-expression-literals": "^7.16.5",
-        "@babel/plugin-transform-modules-amd": "^7.16.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.16.5",
-        "@babel/plugin-transform-modules-systemjs": "^7.16.5",
-        "@babel/plugin-transform-modules-umd": "^7.16.5",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.5",
-        "@babel/plugin-transform-new-target": "^7.16.5",
-        "@babel/plugin-transform-object-super": "^7.16.5",
-        "@babel/plugin-transform-parameters": "^7.16.5",
-        "@babel/plugin-transform-property-literals": "^7.16.5",
-        "@babel/plugin-transform-regenerator": "^7.16.5",
-        "@babel/plugin-transform-reserved-words": "^7.16.5",
-        "@babel/plugin-transform-shorthand-properties": "^7.16.5",
-        "@babel/plugin-transform-spread": "^7.16.5",
-        "@babel/plugin-transform-sticky-regex": "^7.16.5",
-        "@babel/plugin-transform-template-literals": "^7.16.5",
-        "@babel/plugin-transform-typeof-symbol": "^7.16.5",
-        "@babel/plugin-transform-unicode-escapes": "^7.16.5",
-        "@babel/plugin-transform-unicode-regex": "^7.16.5",
+        "@babel/plugin-transform-arrow-functions": "^7.16.7",
+        "@babel/plugin-transform-async-to-generator": "^7.16.7",
+        "@babel/plugin-transform-block-scoped-functions": "^7.16.7",
+        "@babel/plugin-transform-block-scoping": "^7.16.7",
+        "@babel/plugin-transform-classes": "^7.16.7",
+        "@babel/plugin-transform-computed-properties": "^7.16.7",
+        "@babel/plugin-transform-destructuring": "^7.16.7",
+        "@babel/plugin-transform-dotall-regex": "^7.16.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.16.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.16.7",
+        "@babel/plugin-transform-for-of": "^7.16.7",
+        "@babel/plugin-transform-function-name": "^7.16.7",
+        "@babel/plugin-transform-literals": "^7.16.7",
+        "@babel/plugin-transform-member-expression-literals": "^7.16.7",
+        "@babel/plugin-transform-modules-amd": "^7.16.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.16.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.16.7",
+        "@babel/plugin-transform-modules-umd": "^7.16.7",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.7",
+        "@babel/plugin-transform-new-target": "^7.16.7",
+        "@babel/plugin-transform-object-super": "^7.16.7",
+        "@babel/plugin-transform-parameters": "^7.16.7",
+        "@babel/plugin-transform-property-literals": "^7.16.7",
+        "@babel/plugin-transform-regenerator": "^7.16.7",
+        "@babel/plugin-transform-reserved-words": "^7.16.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.16.7",
+        "@babel/plugin-transform-spread": "^7.16.7",
+        "@babel/plugin-transform-sticky-regex": "^7.16.7",
+        "@babel/plugin-transform-template-literals": "^7.16.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.16.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.16.7",
+        "@babel/plugin-transform-unicode-regex": "^7.16.7",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.16.7",
         "babel-plugin-polyfill-corejs2": "^0.3.0",
         "babel-plugin-polyfill-corejs3": "^0.4.0",
         "babel-plugin-polyfill-regenerator": "^0.3.0",
@@ -1660,33 +1661,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.5.tgz",
-      "integrity": "sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.7.tgz",
+      "integrity": "sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.5",
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.5",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1695,12 +1696,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.7.tgz",
+      "integrity": "sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -5744,13 +5745,12 @@
       }
     },
     "node_modules/cssnano": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.13.tgz",
-      "integrity": "sha512-cAmLruIF28a7vKIOieXCTrllaLwbouxV1PPi8Z4M+XloXbmeooWAu4KhJgASo4vQUwbs2pqDgAlnZ1ZKJZKtuw==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.14.tgz",
+      "integrity": "sha512-qzhRkFvBhv08tbyKCIfWbxBXmkIpLl1uNblt8SpTHkgLfON5OCPX/CCnkdNmEosvo8bANQYmTTMEgcVBlisHaw==",
       "dev": true,
       "dependencies": {
         "cssnano-preset-default": "^5.1.9",
-        "is-resolvable": "^1.1.0",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
       },
@@ -9464,12 +9464,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
-    },
-    "node_modules/is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "node_modules/is-stream": {
@@ -19369,9 +19363,9 @@
   },
   "dependencies": {
     "@babel/cli": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.0.tgz",
-      "integrity": "sha512-WLrM42vKX/4atIoQB+eb0ovUof53UUvecb4qGjU2PDDWRiZr50ZpiV8NpcLo7iSxeGYrRG0Mqembsa+UrTAV6Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.16.7.tgz",
+      "integrity": "sha512-0iBF+G2Qml0y3mY5dirolyToLSR88a/KB6F2Gm8J/lOnyL8wbEOHak0DHF8gjc9XZGgTDGv/jYXNiapvsYyHTA==",
       "dev": true,
       "requires": {
         "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
@@ -19386,12 +19380,12 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.16.0"
+        "@babel/highlight": "^7.16.7"
       }
     },
     "@babel/compat-data": {
@@ -19401,20 +19395,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.5.tgz",
-      "integrity": "sha512-wUcenlLzuWMZ9Zt8S0KmFwGlH6QKRh3vsm/dhDA3CHkiTA45YuG1XkHRcNRl73EFPXDp/d5kVOU0/y7x2w6OaQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.7.tgz",
+      "integrity": "sha512-aeLaqcqThRNZYmbMqtulsetOQZ/5gbR/dWruUCJcpas4Qoyy+QeagfDsPdMrqwsPRDNxJvBlRiZxxX7THO7qtA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.5",
-        "@babel/helper-compilation-targets": "^7.16.3",
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helpers": "^7.16.5",
-        "@babel/parser": "^7.16.5",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helpers": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -19435,69 +19429,69 @@
       }
     },
     "@babel/generator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.5.tgz",
-      "integrity": "sha512-kIvCdjZqcdKqoDbVVdt5R99icaRtrtYhYK/xux5qiWCBmfdvEYMFZ68QCrpE5cbFM1JsuArUNs1ZkuKtTtUcZA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.7.tgz",
+      "integrity": "sha512-/ST3Sg8MLGY5HVYmrjOgL60ENux/HfO/CsUh7y4MalThufhE/Ff/6EibFDHi4jiDCaWfJKoqbE6oTh21c5hrRg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.16.7",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
-      "integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.5.tgz",
-      "integrity": "sha512-3JEA9G5dmmnIWdzaT9d0NmFRgYnWUThLsDaL7982H0XqqWr56lRrsmwheXFMjR+TMl7QMBb6mzy9kvgr1lRLUA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
+      "integrity": "sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-explode-assignable-expression": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.16.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
-      "integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+      "integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.16.0",
-        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/compat-data": "^7.16.4",
+        "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.5.tgz",
-      "integrity": "sha512-NEohnYA7mkB8L5JhU7BLwcBdU3j83IziR9aseMueWGeAjblbul3zzb8UvJ3a1zuBiqCMObzCJHFqKIQE6hTVmg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.7.tgz",
+      "integrity": "sha512-kIFozAvVfK05DM4EVQYKK+zteWvY85BFdGBRQBytRyY3y+6PX0DkDOn/CZ3lEuczCfrCxEzwt0YtP/87YPTWSw==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-member-expression-to-functions": "^7.16.5",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/helper-replace-supers": "^7.16.5",
-        "@babel/helper-split-export-declaration": "^7.16.0"
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-member-expression-to-functions": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.0.tgz",
-      "integrity": "sha512-3DyG0zAFAZKcOp7aVr33ddwkxJ0Z0Jr5V99y3I690eYLpukJsJvAbzTy1ewoCqsML8SbIrjH14Jc/nSQ4TvNPA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.16.7.tgz",
+      "integrity": "sha512-fk5A6ymfp+O5+p2yCkXAu5Kyj6v0xh0RBeNcAkYUMDvvAAoxvSKXn+Jb37t/yWFiQVDFK1ELpUTD8/aLhCPu+g==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.16.7",
         "regexpu-core": "^4.7.1"
       }
     },
@@ -19518,132 +19512,132 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.5.tgz",
-      "integrity": "sha512-ODQyc5AnxmZWm/R2W7fzhamOk1ey8gSguo5SGvF0zcB3uUzRpTRmM/jmLSm9bDMyPlvbyJ+PwPEK0BWIoZ9wjg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz",
-      "integrity": "sha512-Hk2SLxC9ZbcOhLpg/yMznzJ11W++lg5GMbxt1ev6TXUiJB0N42KPC+7w8a+eWGuqDnUYuwStJoZHM7RgmIOaGQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz",
+      "integrity": "sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-      "integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+      "integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-get-function-arity": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-      "integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+      "integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-      "integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.5.tgz",
-      "integrity": "sha512-7fecSXq7ZrLE+TWshbGT+HyCLkxloWNhTbU2QM1NTI/tDqyf0oZiMcEfYtDuUDCo528EOlt39G1rftea4bRZIw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.7.tgz",
+      "integrity": "sha512-VtJ/65tYiU/6AbMTDwyoXGPKHgTsfRarivm+YbB5uAzKUyuPjgZSgAFeG87FCigc7KNHu2Pegh1XIT3lXjvz3Q==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
-      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.5.tgz",
-      "integrity": "sha512-CkvMxgV4ZyyioElFwcuWnDCcNIeyqTkCm9BxXZi73RR1ozqlpboqsbGUNvRTflgZtFbbJ1v5Emvm+lkjMYY/LQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+      "integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-simple-access": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-      "integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
+      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.5.tgz",
-      "integrity": "sha512-59KHWHXxVA9K4HNF4sbHCf+eJeFe0Te/ZFGqBT4OjXhrwvA04sGfaEGsVTdsjoszq0YTP49RC9UKe5g8uN2RwQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+      "integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==",
       "dev": true
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.5.tgz",
-      "integrity": "sha512-X+aAJldyxrOmN9v3FKp+Hu1NO69VWgYgDGq6YDykwRPzxs5f2N+X988CBXS7EQahDU+Vpet5QYMqLk+nsp+Qxw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.7.tgz",
+      "integrity": "sha512-C3o117GnP/j/N2OWo+oepeWbFEKRfNaay+F1Eo5Mj3A1SRjyx+qaFhm23nlipub7Cjv2azdUUiDH+VlpdwUFRg==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-wrap-function": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-wrap-function": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.5.tgz",
-      "integrity": "sha512-ao3seGVa/FZCMCCNDuBcqnBFSbdr8N2EW35mzojx3TwfIbdPmNK+JV6+2d5bR0Z71W5ocLnQp9en/cTF7pBJiQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
+      "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
       "dev": true,
       "requires": {
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-member-expression-to-functions": "^7.16.5",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-member-expression-to-functions": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
-      "integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+      "integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -19656,242 +19650,242 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-      "integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true
     },
     "@babel/helper-validator-option": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-      "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
       "dev": true
     },
     "@babel/helper-wrap-function": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.5.tgz",
-      "integrity": "sha512-2J2pmLBqUqVdJw78U0KPNdeE2qeuIyKoG4mKV7wAq3mc4jJG282UgjZw4ZYDnqiWQuS3Y3IYdF/AQ6CpyBV3VA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.7.tgz",
+      "integrity": "sha512-7a9sABeVwcunnztZZ7WTgSw6jVYLzM1wua0Z4HIXm9S3/HC96WKQTkFgGEaj5W06SHHihPJ6Le6HzS5cGOQMNw==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/helpers": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.5.tgz",
-      "integrity": "sha512-TLgi6Lh71vvMZGEkFuIxzaPsyeYCHQ5jJOOX1f0xXn0uciFuE8cEk0wyBquMcCxBXZ5BJhE2aUB7pnWTD150Tw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
+      "integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.16.0",
-        "@babel/traverse": "^7.16.5",
-        "@babel/types": "^7.16.0"
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.7.tgz",
+      "integrity": "sha512-aKpPMfLvGO3Q97V0qhw/V2SWNWlwfJknuwAunU7wZLSfrM4xTBvg7E5opUVi1kJTBKihE38CPg4nBiqX83PWYw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.5.tgz",
-      "integrity": "sha512-+Ce7T5iPNWzfu9C1aB5tN3Lyafs5xb3Ic7vBWyZL2KXT3QSdD1dD3CvgOzPmQKoNNRt6uauc0XwNJTQtXC2/Mw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.7.tgz",
+      "integrity": "sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.16.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.2.tgz",
-      "integrity": "sha512-h37CvpLSf8gb2lIJ2CgC3t+EjFbi0t8qS7LCS1xcJIlEXE4czlofwaW7W1HA8zpgOCzI9C1nmoqNR1zWkk0pQg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.16.7.tgz",
+      "integrity": "sha512-anv/DObl7waiGEnC24O9zqL0pSuI9hljihqiDuFHC8d7/bjr/4RLGPWuc8rYOff/QPzbEPSkzG8wGG9aDuhHRg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.0.tgz",
-      "integrity": "sha512-4tcFwwicpWTrpl9qjf7UsoosaArgImF85AxqCRZlgc3IQDvkUHjJpruXAL58Wmj+T6fypWTC/BakfEkwIL/pwA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.16.7.tgz",
+      "integrity": "sha512-di8vUHRdf+4aJ7ltXhaDbPoszdkh59AQtJM5soLsuHpQJdFQZOA4uGj0V2u/CZ8bJ/u8ULDL5yq6FO/bCXnKHw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.16.0"
+        "@babel/plugin-proposal-optional-chaining": "^7.16.7"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.5.tgz",
-      "integrity": "sha512-C/FX+3HNLV6sz7AqbTQqEo1L9/kfrKjxcVtgyBCmvIgOjvuBVUWooDoi7trsLxOzCEo5FccjRvKHkfDsJFZlfA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.16.7.tgz",
+      "integrity": "sha512-TTXBT3A5c11eqRzaC6beO6rlFT3Mo9C2e8eB44tTr52ESXSK2CIc2fOp1ynpAwQA8HhBMho+WXhMHWlAe3xkpw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-remap-async-to-generator": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-remap-async-to-generator": "^7.16.7",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.5.tgz",
-      "integrity": "sha512-pJD3HjgRv83s5dv1sTnDbZOaTjghKEz8KUn1Kbh2eAIRhGuyQ1XSeI4xVXU3UlIEVA3DAyIdxqT1eRn7Wcn55A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.16.7.tgz",
+      "integrity": "sha512-IobU0Xme31ewjYOShSIqd/ZGM/r/cuOz2z0MDbNrhF5FW+ZVgi0f2lyeoj9KFPDOAqsYxmLWZte1WOwlvY9aww==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-proposal-class-static-block": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.5.tgz",
-      "integrity": "sha512-EEFzuLZcm/rNJ8Q5krK+FRKdVkd6FjfzT9tuSZql9sQn64K0hHA2KLJ0DqVot9/iV6+SsuadC5yI39zWnm+nmQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.16.7.tgz",
+      "integrity": "sha512-dgqJJrcZoG/4CkMopzhPJjGxsIe9A8RlkQLnL/Vhhx8AA9ZuaRwGSlscSh42hazc7WSrya/IK7mTeoF0DP9tEw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.5.tgz",
-      "integrity": "sha512-P05/SJZTTvHz79LNYTF8ff5xXge0kk5sIIWAypcWgX4BTRUgyHc8wRxJ/Hk+mU0KXldgOOslKaeqnhthcDJCJQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
+      "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.5.tgz",
-      "integrity": "sha512-i+sltzEShH1vsVydvNaTRsgvq2vZsfyrd7K7vPLUU/KgS0D5yZMe6uipM0+izminnkKrEfdUnz7CxMRb6oHZWw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.16.7.tgz",
+      "integrity": "sha512-ZxdtqDXLRGBL64ocZcs7ovt71L3jhC1RGSyR996svrCi3PYqHNkb3SwPJCs8RIzD86s+WPpt2S73+EHCGO+NUA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-json-strings": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.5.tgz",
-      "integrity": "sha512-QQJueTFa0y9E4qHANqIvMsuxM/qcLQmKttBACtPCQzGUEizsXDACGonlPiSwynHfOa3vNw0FPMVvQzbuXwh4SQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.16.7.tgz",
+      "integrity": "sha512-lNZ3EEggsGY78JavgbHsK9u5P3pQaW7k4axlgFLYkMd7UBsiNahCITShLjNQschPyjtO6dADrL24757IdhBrsQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.5.tgz",
-      "integrity": "sha512-xqibl7ISO2vjuQM+MzR3rkd0zfNWltk7n9QhaD8ghMmMceVguYrNDt7MikRyj4J4v3QehpnrU8RYLnC7z/gZLA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.16.7.tgz",
+      "integrity": "sha512-K3XzyZJGQCr00+EtYtrDjmwX7o7PLK6U9bi1nCwkQioRFVUv6dJoxbQjtWVtP+bCPy82bONBKG8NPyQ4+i6yjg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.5.tgz",
-      "integrity": "sha512-YwMsTp/oOviSBhrjwi0vzCUycseCYwoXnLiXIL3YNjHSMBHicGTz7GjVU/IGgz4DtOEXBdCNG72pvCX22ehfqg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.16.7.tgz",
+      "integrity": "sha512-aUOrYU3EVtjf62jQrCj63pYZ7k6vns2h/DQvHPWGmsJRYzWXZ6/AsfgpiRy6XiuIDADhJzP2Q9MwSMKauBQ+UQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.5.tgz",
-      "integrity": "sha512-DvB9l/TcsCRvsIV9v4jxR/jVP45cslTVC0PMVHvaJhhNuhn2Y1SOhCSFlPK777qLB5wb8rVDaNoqMTyOqtY5Iw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
+      "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.5.tgz",
-      "integrity": "sha512-UEd6KpChoyPhCoE840KRHOlGhEZFutdPDMGj+0I56yuTTOaT51GzmnEl/0uT41fB/vD2nT+Pci2KjezyE3HmUw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.16.7.tgz",
+      "integrity": "sha512-3O0Y4+dw94HA86qSg9IHfyPktgR7q3gpNVAeiKQd+8jBKFaU5NQS1Yatgo4wY+UFNuLjvxcSmzcsHqrhgTyBUA==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.16.4",
-        "@babel/helper-compilation-targets": "^7.16.3",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.16.5"
+        "@babel/plugin-transform-parameters": "^7.16.7"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.5.tgz",
-      "integrity": "sha512-ihCMxY1Iljmx4bWy/PIMJGXN4NS4oUj1MKynwO07kiKms23pNvIn1DMB92DNB2R0EA882sw0VXIelYGdtF7xEQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz",
+      "integrity": "sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.5.tgz",
-      "integrity": "sha512-kzdHgnaXRonttiTfKYnSVafbWngPPr2qKw9BWYBESl91W54e+9R5pP70LtWxV56g0f05f/SQrwHYkfvbwcdQ/A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.16.7.tgz",
+      "integrity": "sha512-eC3xy+ZrUcBtP7x+sq62Q/HYd674pPTb/77XZMb5wbDPGWIdUbSr4Agr052+zaUPSb+gGRnjxXfKFvx5iMJ+DA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-private-methods": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.5.tgz",
-      "integrity": "sha512-+yFMO4BGT3sgzXo+lrq7orX5mAZt57DwUK6seqII6AcJnJOIhBJ8pzKH47/ql/d426uQ7YhN8DpUFirQzqYSUA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.16.7.tgz",
+      "integrity": "sha512-7twV3pzhrRxSwHeIvFE6coPgvo+exNDOiGUMg39o2LiLo1Y+4aKpfkcLGcg1UHonzorCt7SNXnoMyCnnIOA8Sw==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.5.tgz",
-      "integrity": "sha512-+YGh5Wbw0NH3y/E5YMu6ci5qTDmAEVNoZ3I54aB6nVEOZ5BQ7QJlwKq5pYVucQilMByGn/bvX0af+uNaPRCabA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.16.7.tgz",
+      "integrity": "sha512-rMQkjcOFbm+ufe3bTZLyOfsOUOxyvLXZJCTARhJr+8UMSoZmqTe1K1BgkFcrW37rAchWg57yI69ORxiWvUINuQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-create-class-features-plugin": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-create-class-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.5.tgz",
-      "integrity": "sha512-s5sKtlKQyFSatt781HQwv1hoM5BQ9qRH30r+dK56OLDsHmV74mzwJNX7R1yMuE7VZKG5O6q/gmOGSAO6ikTudg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.16.7.tgz",
+      "integrity": "sha512-QRK0YI/40VLhNVGIjRNAAQkEHws0cswSdFFjpFyt943YmJIU1da9uW63Iu6NFV6CxTZW5eTDCrwZUstBWgp/Rg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -20039,345 +20033,346 @@
       }
     },
     "@babel/plugin-transform-arrow-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.5.tgz",
-      "integrity": "sha512-8bTHiiZyMOyfZFULjsCnYOWG059FVMes0iljEHSfARhNgFfpsqE92OrCffv3veSw9rwMkYcFe9bj0ZoXU2IGtQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.16.7.tgz",
+      "integrity": "sha512-9ffkFFMbvzTvv+7dTp/66xvZAWASuPD5Tl9LK3Z9vhOmANo6j94rik+5YMBt4CwHVMWLWpMsriIc2zsa3WW3xQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-async-to-generator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.5.tgz",
-      "integrity": "sha512-TMXgfioJnkXU+XRoj7P2ED7rUm5jbnDWwlCuFVTpQboMfbSya5WrmubNBAMlk7KXvywpo8rd8WuYZkis1o2H8w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.16.7.tgz",
+      "integrity": "sha512-pFEfjnK4DfXCfAlA5I98BYdDJD8NltMzx19gt6DAmfE+2lXRfPUoa0/5SUjT4+TDE1W/rcxU/1lgN55vpAjjdg==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-remap-async-to-generator": "^7.16.5"
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-remap-async-to-generator": "^7.16.7"
       }
     },
     "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.5.tgz",
-      "integrity": "sha512-BxmIyKLjUGksJ99+hJyL/HIxLIGnLKtw772zYDER7UuycDZ+Xvzs98ZQw6NGgM2ss4/hlFAaGiZmMNKvValEjw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
+      "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.5.tgz",
-      "integrity": "sha512-JxjSPNZSiOtmxjX7PBRBeRJTUKTyJ607YUYeT0QJCNdsedOe+/rXITjP08eG8xUpsLfPirgzdCFN+h0w6RI+pQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.16.7.tgz",
+      "integrity": "sha512-ObZev2nxVAYA4bhyusELdo9hb3H+A56bxH3FZMbEImZFiEDYVHXQSJ1hQKFlDnlt8G9bBrCZ5ZpURZUrV4G5qQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.5.tgz",
-      "integrity": "sha512-DzJ1vYf/7TaCYy57J3SJ9rV+JEuvmlnvvyvYKFbk5u46oQbBvuB9/0w+YsVsxkOv8zVWKpDmUoj4T5ILHoXevA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.16.7.tgz",
+      "integrity": "sha512-WY7og38SFAGYRe64BrjKf8OrE6ulEHtr5jEYaZMwox9KebgqPi67Zqz8K53EKk1fFEJgm96r32rkKZ3qA2nCWQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.0",
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-optimise-call-expression": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-replace-supers": "^7.16.5",
-        "@babel/helper-split-export-declaration": "^7.16.0",
+        "@babel/helper-annotate-as-pure": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-optimise-call-expression": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.5.tgz",
-      "integrity": "sha512-n1+O7xtU5lSLraRzX88CNcpl7vtGdPakKzww74bVwpAIRgz9JVLJJpOLb0uYqcOaXVM0TL6X0RVeIJGD2CnCkg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.16.7.tgz",
+      "integrity": "sha512-gN72G9bcmenVILj//sv1zLNaPyYcOzUho2lIJBMh/iakJ9ygCo/hEF9cpGb61SCMEDxbbyBoVQxrt+bWKu5KGw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.5.tgz",
-      "integrity": "sha512-GuRVAsjq+c9YPK6NeTkRLWyQskDC099XkBSVO+6QzbnOnH2d/4mBVXYStaPrZD3dFRfg00I6BFJ9Atsjfs8mlg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.7.tgz",
+      "integrity": "sha512-VqAwhTHBnu5xBVDCvrvqJbtLUa++qZaWC0Fgr2mqokBlulZARGyIvZDoqbPlPaKImQ9dKAcCzbv+ul//uqu70A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.5.tgz",
-      "integrity": "sha512-iQiEMt8Q4/5aRGHpGVK2Zc7a6mx7qEAO7qehgSug3SDImnuMzgmm/wtJALXaz25zUj1PmnNHtShjFgk4PDx4nw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz",
+      "integrity": "sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.5.tgz",
-      "integrity": "sha512-81tijpDg2a6I1Yhj4aWY1l3O1J4Cg/Pd7LfvuaH2VVInAkXtzibz9+zSPdUM1WvuUi128ksstAP0hM5w48vQgg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.16.7.tgz",
+      "integrity": "sha512-03DvpbRfvWIXyK0/6QiR1KMTWeT6OcQ7tbhjrXyFS02kjuX/mu5Bvnh5SDSWHxyawit2g5aWhKwI86EE7GUnTw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.5.tgz",
-      "integrity": "sha512-12rba2HwemQPa7BLIKCzm1pT2/RuQHtSFHdNl41cFiC6oi4tcrp7gjB07pxQvFpcADojQywSjblQth6gJyE6CA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz",
+      "integrity": "sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.5.tgz",
-      "integrity": "sha512-+DpCAJFPAvViR17PIMi9x2AE34dll5wNlXO43wagAX2YcRGgEVHCNFC4azG85b4YyyFarvkc/iD5NPrz4Oneqw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.16.7.tgz",
+      "integrity": "sha512-/QZm9W92Ptpw7sjI9Nx1mbcsWz33+l8kuMIQnDwgQBG5s3fAfQvkRjQ7NqXhtNcKOnPkdICmUHyCaWW06HCsqg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.5.tgz",
-      "integrity": "sha512-Fuec/KPSpVLbGo6z1RPw4EE1X+z9gZk1uQmnYy7v4xr4TO9p41v1AoUuXEtyqAI7H+xNJYSICzRqZBhDEkd3kQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
+      "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.5.tgz",
-      "integrity": "sha512-B1j9C/IfvshnPcklsc93AVLTrNVa69iSqztylZH6qnmiAsDDOmmjEYqOm3Ts2lGSgTSywnBNiqC949VdD0/gfw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.16.7.tgz",
+      "integrity": "sha512-6tH8RTpTWI0s2sV6uq3e/C9wPo4PTqqZps4uF0kzQ9/xPLFQtipynvmT1g/dOfEJ+0EQsHhkQ/zyRId8J2b8zQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.5.tgz",
-      "integrity": "sha512-d57i3vPHWgIde/9Y8W/xSFUndhvhZN5Wu2TjRrN1MVz5KzdUihKnfDVlfP1U7mS5DNj/WHHhaE4/tTi4hIyHwQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
+      "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.5.tgz",
-      "integrity": "sha512-oHI15S/hdJuSCfnwIz+4lm6wu/wBn7oJ8+QrkzPPwSFGXk8kgdI/AIKcbR/XnD1nQVMg/i6eNaXpszbGuwYDRQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.16.7.tgz",
+      "integrity": "sha512-KaaEtgBL7FKYwjJ/teH63oAmE3lP34N3kshz8mm4VMAw7U3PxjVwwUmxEFksbgsNUaO3wId9R2AVQYSEGRa2+g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.5.tgz",
-      "integrity": "sha512-ABhUkxvoQyqhCWyb8xXtfwqNMJD7tx+irIRnUh6lmyFud7Jln1WzONXKlax1fg/ey178EXbs4bSGNd6PngO+SQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.7.tgz",
+      "integrity": "sha512-h2RP2kE7He1ZWKyAlanMZrAbdv+Acw1pA8dQZhE025WJZE2z0xzFADAinXA9fxd5bn7JnM+SdOGcndGx1ARs9w==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-simple-access": "^7.16.0",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-simple-access": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.5.tgz",
-      "integrity": "sha512-53gmLdScNN28XpjEVIm7LbWnD/b/TpbwKbLk6KV4KqC9WyU6rq1jnNmVG6UgAdQZVVGZVoik3DqHNxk4/EvrjA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.16.7.tgz",
+      "integrity": "sha512-DuK5E3k+QQmnOqBR9UkusByy5WZWGRxfzV529s9nPra1GE7olmxfqO2FHobEOYSPIjPBTr4p66YDcjQnt8cBmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.5.tgz",
-      "integrity": "sha512-qTFnpxHMoenNHkS3VoWRdwrcJ3FhX567GvDA3hRZKF0Dj8Fmg0UzySZp3AP2mShl/bzcywb/UWAMQIjA1bhXvw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.16.7.tgz",
+      "integrity": "sha512-EMh7uolsC8O4xhudF2F6wedbSHm1HHZ0C6aJ7K67zcDNidMzVcxWdGr+htW9n21klm+bOn+Rx4CBsAntZd3rEQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.16.5",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-module-transforms": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.5.tgz",
-      "integrity": "sha512-/wqGDgvFUeKELW6ex6QB7dLVRkd5ehjw34tpXu1nhKC0sFfmaLabIswnpf8JgDyV2NeDmZiwoOb0rAmxciNfjA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.16.7.tgz",
+      "integrity": "sha512-kFy35VwmwIQwCjwrAQhl3+c/kr292i4KdLPKp5lPH03Ltc51qnFlIADoyPxc/6Naz3ok3WdYKg+KK6AH+D4utg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.5.tgz",
-      "integrity": "sha512-ZaIrnXF08ZC8jnKR4/5g7YakGVL6go6V9ql6Jl3ecO8PQaQqFE74CuM384kezju7Z9nGCCA20BqZaR1tJ/WvHg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.16.7.tgz",
+      "integrity": "sha512-xiLDzWNMfKoGOpc6t3U+etCE2yRnn3SM09BXqWPIZOBpL2gvVrBWUKnsJx0K/ADi5F5YC5f8APFfWrz25TdlGg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.5.tgz",
-      "integrity": "sha512-tded+yZEXuxt9Jdtkc1RraW1zMF/GalVxaVVxh41IYwirdRgyAxxxCKZ9XB7LxZqmsjfjALxupNE1MIz9KH+Zg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
+      "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-replace-supers": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-replace-supers": "^7.16.7"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.5.tgz",
-      "integrity": "sha512-B3O6AL5oPop1jAVg8CV+haeUte9oFuY85zu0jwnRNZZi3tVAbJriu5tag/oaO2kGaQM/7q7aGPBlTI5/sr9enA==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
+      "integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-property-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.5.tgz",
-      "integrity": "sha512-+IRcVW71VdF9pEH/2R/Apab4a19LVvdVsr/gEeotH00vSDVlKD+XgfSIw+cgGWsjDB/ziqGv/pGoQZBIiQVXHg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
+      "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.5.tgz",
-      "integrity": "sha512-2z+it2eVWU8TtQQRauvGUqZwLy4+7rTfo6wO4npr+fvvN1SW30ZF3O/ZRCNmTuu4F5MIP8OJhXAhRV5QMJOuYg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.16.7.tgz",
+      "integrity": "sha512-mF7jOgGYCkSJagJ6XCujSQg+6xC1M77/03K2oBmVJWoFGNUtnVJO4WHKJk3dnPC8HCcj4xBQP1Egm8DWh3Pb3Q==",
       "dev": true,
       "requires": {
         "regenerator-transform": "^0.14.2"
       }
     },
     "@babel/plugin-transform-reserved-words": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.5.tgz",
-      "integrity": "sha512-aIB16u8lNcf7drkhXJRoggOxSTUAuihTSTfAcpynowGJOZiGf+Yvi7RuTwFzVYSYPmWyARsPqUGoZWWWxLiknw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.16.7.tgz",
+      "integrity": "sha512-KQzzDnZ9hWQBjwi5lpY5v9shmm6IVG0U9pB18zvMu2i4H90xpT4gmqwPYsn8rObiadYe2M0gmgsiOIF5A/2rtg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.5.tgz",
-      "integrity": "sha512-ZbuWVcY+MAXJuuW7qDoCwoxDUNClfZxoo7/4swVbOW1s/qYLOMHlm9YRWMsxMFuLs44eXsv4op1vAaBaBaDMVg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
+      "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.5.tgz",
-      "integrity": "sha512-5d6l/cnG7Lw4tGHEoga4xSkYp1euP7LAtrah1h1PgJ3JY7yNsjybsxQAnVK4JbtReZ/8z6ASVmd3QhYYKLaKZw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.16.7.tgz",
+      "integrity": "sha512-+pjJpgAngb53L0iaA5gU/1MLXJIfXcYepLgXB3esVRf4fqmj8f2cxM3/FKaHsZms08hFQJkFccEWuIpm429TXg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.5.tgz",
-      "integrity": "sha512-usYsuO1ID2LXxzuUxifgWtJemP7wL2uZtyrTVM4PKqsmJycdS4U4mGovL5xXkfUheds10Dd2PjoQLXw6zCsCbg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz",
+      "integrity": "sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.5.tgz",
-      "integrity": "sha512-gnyKy9RyFhkovex4BjKWL3BVYzUDG6zC0gba7VMLbQoDuqMfJ1SDXs8k/XK41Mmt1Hyp4qNAvGFb9hKzdCqBRQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.16.7.tgz",
+      "integrity": "sha512-VwbkDDUeenlIjmfNeDX/V0aWrQH2QiVyJtwymVQSzItFDTpxfyJh3EVaQiS0rIN/CqbLGr0VcGmuwyTdZtdIsA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.5.tgz",
-      "integrity": "sha512-ldxCkW180qbrvyCVDzAUZqB0TAeF8W/vGJoRcaf75awm6By+PxfJKvuqVAnq8N9wz5Xa6mSpM19OfVKKVmGHSQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.16.7.tgz",
+      "integrity": "sha512-p2rOixCKRJzpg9JB4gjnG4gjWkWa89ZoYUnl9snJ1cWIcTH/hvxZqfO+WjG6T8DRBpctEol5jw1O5rA8gkCokQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-unicode-escapes": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.5.tgz",
-      "integrity": "sha512-shiCBHTIIChGLdyojsKQjoAyB8MBwat25lKM7MJjbe1hE0bgIppD+LX9afr41lLHOhqceqeWl4FkLp+Bgn9o1Q==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
+      "integrity": "sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.5.tgz",
-      "integrity": "sha512-GTJ4IW012tiPEMMubd7sD07iU9O/LOo8Q/oU4xNhcaq0Xn8+6TcUQaHtC8YxySo1T+ErQ8RaWogIEeFhKGNPzw==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz",
+      "integrity": "sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.16.5"
+        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7"
       }
     },
     "@babel/preset-env": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.5.tgz",
-      "integrity": "sha512-MiJJW5pwsktG61NDxpZ4oJ1CKxM1ncam9bzRtx9g40/WkLRkxFP6mhpkYV0/DxcciqoiHicx291+eUQrXb/SfQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.16.7.tgz",
+      "integrity": "sha512-urX3Cee4aOZbRWOSa3mKPk0aqDikfILuo+C7qq7HY0InylGNZ1fekq9jmlr3pLWwZHF4yD7heQooc2Pow2KMyQ==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.16.4",
-        "@babel/helper-compilation-targets": "^7.16.3",
-        "@babel/helper-plugin-utils": "^7.16.5",
-        "@babel/helper-validator-option": "^7.14.5",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.2",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.0",
-        "@babel/plugin-proposal-async-generator-functions": "^7.16.5",
-        "@babel/plugin-proposal-class-properties": "^7.16.5",
-        "@babel/plugin-proposal-class-static-block": "^7.16.5",
-        "@babel/plugin-proposal-dynamic-import": "^7.16.5",
-        "@babel/plugin-proposal-export-namespace-from": "^7.16.5",
-        "@babel/plugin-proposal-json-strings": "^7.16.5",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.16.5",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.5",
-        "@babel/plugin-proposal-numeric-separator": "^7.16.5",
-        "@babel/plugin-proposal-object-rest-spread": "^7.16.5",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.16.5",
-        "@babel/plugin-proposal-optional-chaining": "^7.16.5",
-        "@babel/plugin-proposal-private-methods": "^7.16.5",
-        "@babel/plugin-proposal-private-property-in-object": "^7.16.5",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.16.5",
+        "@babel/helper-compilation-targets": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-validator-option": "^7.16.7",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.16.7",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.16.7",
+        "@babel/plugin-proposal-async-generator-functions": "^7.16.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.7",
+        "@babel/plugin-proposal-class-static-block": "^7.16.7",
+        "@babel/plugin-proposal-dynamic-import": "^7.16.7",
+        "@babel/plugin-proposal-export-namespace-from": "^7.16.7",
+        "@babel/plugin-proposal-json-strings": "^7.16.7",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.16.7",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.16.7",
+        "@babel/plugin-proposal-numeric-separator": "^7.16.7",
+        "@babel/plugin-proposal-object-rest-spread": "^7.16.7",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
+        "@babel/plugin-proposal-optional-chaining": "^7.16.7",
+        "@babel/plugin-proposal-private-methods": "^7.16.7",
+        "@babel/plugin-proposal-private-property-in-object": "^7.16.7",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.16.7",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
@@ -20392,40 +20387,40 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.16.5",
-        "@babel/plugin-transform-async-to-generator": "^7.16.5",
-        "@babel/plugin-transform-block-scoped-functions": "^7.16.5",
-        "@babel/plugin-transform-block-scoping": "^7.16.5",
-        "@babel/plugin-transform-classes": "^7.16.5",
-        "@babel/plugin-transform-computed-properties": "^7.16.5",
-        "@babel/plugin-transform-destructuring": "^7.16.5",
-        "@babel/plugin-transform-dotall-regex": "^7.16.5",
-        "@babel/plugin-transform-duplicate-keys": "^7.16.5",
-        "@babel/plugin-transform-exponentiation-operator": "^7.16.5",
-        "@babel/plugin-transform-for-of": "^7.16.5",
-        "@babel/plugin-transform-function-name": "^7.16.5",
-        "@babel/plugin-transform-literals": "^7.16.5",
-        "@babel/plugin-transform-member-expression-literals": "^7.16.5",
-        "@babel/plugin-transform-modules-amd": "^7.16.5",
-        "@babel/plugin-transform-modules-commonjs": "^7.16.5",
-        "@babel/plugin-transform-modules-systemjs": "^7.16.5",
-        "@babel/plugin-transform-modules-umd": "^7.16.5",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.5",
-        "@babel/plugin-transform-new-target": "^7.16.5",
-        "@babel/plugin-transform-object-super": "^7.16.5",
-        "@babel/plugin-transform-parameters": "^7.16.5",
-        "@babel/plugin-transform-property-literals": "^7.16.5",
-        "@babel/plugin-transform-regenerator": "^7.16.5",
-        "@babel/plugin-transform-reserved-words": "^7.16.5",
-        "@babel/plugin-transform-shorthand-properties": "^7.16.5",
-        "@babel/plugin-transform-spread": "^7.16.5",
-        "@babel/plugin-transform-sticky-regex": "^7.16.5",
-        "@babel/plugin-transform-template-literals": "^7.16.5",
-        "@babel/plugin-transform-typeof-symbol": "^7.16.5",
-        "@babel/plugin-transform-unicode-escapes": "^7.16.5",
-        "@babel/plugin-transform-unicode-regex": "^7.16.5",
+        "@babel/plugin-transform-arrow-functions": "^7.16.7",
+        "@babel/plugin-transform-async-to-generator": "^7.16.7",
+        "@babel/plugin-transform-block-scoped-functions": "^7.16.7",
+        "@babel/plugin-transform-block-scoping": "^7.16.7",
+        "@babel/plugin-transform-classes": "^7.16.7",
+        "@babel/plugin-transform-computed-properties": "^7.16.7",
+        "@babel/plugin-transform-destructuring": "^7.16.7",
+        "@babel/plugin-transform-dotall-regex": "^7.16.7",
+        "@babel/plugin-transform-duplicate-keys": "^7.16.7",
+        "@babel/plugin-transform-exponentiation-operator": "^7.16.7",
+        "@babel/plugin-transform-for-of": "^7.16.7",
+        "@babel/plugin-transform-function-name": "^7.16.7",
+        "@babel/plugin-transform-literals": "^7.16.7",
+        "@babel/plugin-transform-member-expression-literals": "^7.16.7",
+        "@babel/plugin-transform-modules-amd": "^7.16.7",
+        "@babel/plugin-transform-modules-commonjs": "^7.16.7",
+        "@babel/plugin-transform-modules-systemjs": "^7.16.7",
+        "@babel/plugin-transform-modules-umd": "^7.16.7",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.16.7",
+        "@babel/plugin-transform-new-target": "^7.16.7",
+        "@babel/plugin-transform-object-super": "^7.16.7",
+        "@babel/plugin-transform-parameters": "^7.16.7",
+        "@babel/plugin-transform-property-literals": "^7.16.7",
+        "@babel/plugin-transform-regenerator": "^7.16.7",
+        "@babel/plugin-transform-reserved-words": "^7.16.7",
+        "@babel/plugin-transform-shorthand-properties": "^7.16.7",
+        "@babel/plugin-transform-spread": "^7.16.7",
+        "@babel/plugin-transform-sticky-regex": "^7.16.7",
+        "@babel/plugin-transform-template-literals": "^7.16.7",
+        "@babel/plugin-transform-typeof-symbol": "^7.16.7",
+        "@babel/plugin-transform-unicode-escapes": "^7.16.7",
+        "@babel/plugin-transform-unicode-regex": "^7.16.7",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.16.0",
+        "@babel/types": "^7.16.7",
         "babel-plugin-polyfill-corejs2": "^0.3.0",
         "babel-plugin-polyfill-corejs3": "^0.4.0",
         "babel-plugin-polyfill-regenerator": "^0.3.0",
@@ -20466,41 +20461,41 @@
       }
     },
     "@babel/template": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-      "integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/parser": "^7.16.0",
-        "@babel/types": "^7.16.0"
+        "@babel/code-frame": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.16.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.5.tgz",
-      "integrity": "sha512-FOCODAzqUMROikDYLYxl4nmwiLlu85rNqBML/A5hKRVXG2LV8d0iMqgPzdYTcIpjZEBB7D6UDU9vxRZiriASdQ==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.7.tgz",
+      "integrity": "sha512-8KWJPIb8c2VvY8AJrydh6+fVRo2ODx1wYBU2398xJVq0JomuLBZmVQzLPBblJgHIGYG4znCpUZUZ0Pt2vdmVYQ==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.16.0",
-        "@babel/generator": "^7.16.5",
-        "@babel/helper-environment-visitor": "^7.16.5",
-        "@babel/helper-function-name": "^7.16.0",
-        "@babel/helper-hoist-variables": "^7.16.0",
-        "@babel/helper-split-export-declaration": "^7.16.0",
-        "@babel/parser": "^7.16.5",
-        "@babel/types": "^7.16.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.16.7",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.16.7",
+        "@babel/types": "^7.16.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.7.tgz",
+      "integrity": "sha512-E8HuV7FO9qLpx6OtoGfUQ2cjIYnbFwvZWYBS+87EwtdMvmUPJSwykpovFB+8insbpF0uJcpr8KMUi64XZntZcg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -23667,13 +23662,12 @@
       "dev": true
     },
     "cssnano": {
-      "version": "5.0.13",
-      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.13.tgz",
-      "integrity": "sha512-cAmLruIF28a7vKIOieXCTrllaLwbouxV1PPi8Z4M+XloXbmeooWAu4KhJgASo4vQUwbs2pqDgAlnZ1ZKJZKtuw==",
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-5.0.14.tgz",
+      "integrity": "sha512-qzhRkFvBhv08tbyKCIfWbxBXmkIpLl1uNblt8SpTHkgLfON5OCPX/CCnkdNmEosvo8bANQYmTTMEgcVBlisHaw==",
       "dev": true,
       "requires": {
         "cssnano-preset-default": "^5.1.9",
-        "is-resolvable": "^1.1.0",
         "lilconfig": "^2.0.3",
         "yaml": "^1.10.2"
       }
@@ -26512,12 +26506,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true
-    },
-    "is-resolvable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
-      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
       "dev": true
     },
     "is-stream": {

--- a/public/components.html
+++ b/public/components.html
@@ -365,7 +365,7 @@
 
     </div>
 
-    <!-- Buttons: Save file, Save as SVG, zoom, undo/redo, menu, metadata, filters, add a new note, bookmark note, naturalize note -->
+    <!-- Buttons: Save file, Save as SVG, zoom, undo/redo, menu, metadata, filters, selection mode, add a new note, bookmark note, naturalize note -->
 
     <button class="btn btn--hollow" type="button">Save file</button>
     <button class="btn btn--hollow" type="button"><span>Save as <abbr title="Scalable Vector Graphics">SVG</abbr></span></button>
@@ -401,6 +401,32 @@
         </button>
 
     </div>
+
+    <fieldset class="btn btn--hollow btn-tabs btn-tabs--radio">
+
+        <!-- Primary -->
+        <label
+            class="btn-tabs__btn"
+            style="--btn-checked: hsl(4, 81%, 49%);"
+            for="selection-mode-primary"
+            data-label="Primary"
+        >
+            <input class="btn-tabs__radio" type="radio" name="selection-mode" id="selection-mode-primary" value="primary">
+            <span class="btn btn--hollow btn-tabs__accent">Primary</span>
+        </label>
+
+        <!-- Secondary -->
+        <label
+            class="btn-tabs__btn"
+            style="--btn-checked: hsl(199, 98%, 55%);"
+            for="selection-mode-secondary"
+            data-label="Secondary"
+        >
+            <input class="btn-tabs__radio" type="radio" name="selection-mode" id="selection-mode-secondary" value="secondary">
+            <span class="btn btn--hollow btn-tabs__accent">Secondary</span>
+        </label>
+
+    </fieldset>
 
     <!-- Main menu button -->
     <button class="btn btn--plain" type="button">

--- a/public/index.html
+++ b/public/index.html
@@ -349,12 +349,13 @@
             </div>
         </div>
 
-        <!-- Undo, redo, (un)select all -->
+        <!-- Undo, redo, (un)select all, primary/secondary -->
 
         <div id="history-and-selection" class="history-and-selection | flex-center">
 
-            <div class="btn-tabs">
+            <div class="btn-tabs btn-tabs--with-separator">
 
+                <!-- Undo -->
                 <button id="undo" class="undo | btn btn--small btn-tabs__btn" type="button">
                     <svg class="btn__icon" width="20" height="20">
                         <use xlink:href="#undo-path"/>
@@ -362,6 +363,7 @@
                     <span class="visually-hidden">Undo</span>
                 </button>
 
+                <!-- Redo -->
                 <button id="redo" class="redo | btn btn--small btn-tabs__btn" type="button">
                     <svg class="redo__icon btn__icon" width="20" height="20">
                         <use xlink:href="#undo-path"/>
@@ -371,8 +373,36 @@
 
             </div>
 
+            <!-- (Un)select all -->
             <button id="select-all" class="btn btn--hollow" type="button">Select visible relations</button>
             <button id="unselect-all" class="btn btn--hollow" type="button">Unselect all</button>
+
+            <!-- Selection mode -->
+            <fieldset class="btn btn--hollow btn-tabs btn-tabs--radio">
+
+                <!-- Primary -->
+                <label
+                    class="btn-tabs__btn"
+                    style="--btn-checked: hsl(4, 81%, 49%);"
+                    for="selection-mode-primary"
+                    data-label="Primary"
+                >
+                    <input class="btn-tabs__radio" type="radio" name="selection-mode" id="selection-mode-primary" value="primary">
+                    <span class="btn btn--hollow btn-tabs__accent">Primary</span>
+                </label>
+
+                <!-- Secondary -->
+                <label
+                    class="btn-tabs__btn"
+                    style="--btn-checked: hsl(199, 98%, 55%);"
+                    for="selection-mode-secondary"
+                    data-label="Secondary"
+                >
+                    <input class="btn-tabs__radio" type="radio" name="selection-mode" id="selection-mode-secondary" value="secondary">
+                    <span class="btn btn--hollow btn-tabs__accent">Secondary</span>
+                </label>
+
+            </fieldset>
 
         </div>
 
@@ -534,12 +564,6 @@
             <input type="button" id="addnotebutton" value="Toggle adding a note"/>
             <input type="button" id="addbookmarkbutton" value="Bookmark note"/>
             <input type="button" id="naturalizebutton" value="Naturali(Z)e notes"/>
-        </div>
-        <div id="relation_buttons">
-        </div>
-        <div id="meta_buttons" class="none">
-        </div>
-        <div id="combo_buttons">
         </div>
     </div>
 

--- a/src/js/accidentals.js
+++ b/src/js/accidentals.js
@@ -14,7 +14,6 @@ export function naturalize_notes() {
   var sel = selected.concat(extraselected)
   sel.forEach(naturalize_note)
   sel.forEach(toggle_selected)
-
 }
 
 const naturalizeNotesButton = document.getElementById('naturalizebutton')

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -570,7 +570,7 @@ function finalize_draw_context(new_draw_context) {
   draw_contexts.reverse()
   add_buttons(new_draw_context)
   for (let n of new_draw_context.svg_elem.getElementsByClassName('note')) {
-    n.onclick = function(ev) { toggle_selected(n, ev.shiftKey) }
+    n.onclick = () => toggle_selected(n)
   }
   for (let s of new_draw_context.svg_elem.getElementsByClassName('staff')) {
     // TODO: handle staves with no notes in them

--- a/src/js/coordinates.js
+++ b/src/js/coordinates.js
@@ -279,7 +279,7 @@ function draw_note(pname, oct, note, sim = true, id = '') {
     gh.appendChild(u)
     g.appendChild(gh)
     note.parentElement.appendChild(g)
-    g.onclick = function(ev) { toggle_selected(g, ev.shiftKey) }
+    g.onclick = () => toggle_selected(g)
     added.push(g)
   }
   return added.reverse()

--- a/src/js/copy_paste.js
+++ b/src/js/copy_paste.js
@@ -45,10 +45,10 @@ export function do_paste() {
   let p_offs = copy.template.map((n) => n.p_off)
   p_offs = p_offs.sort((a, b) => a - b)
   // Find matching notes according to map
-  let n_candidates = notes_in_range(n_ref, p_offs[0], 
+  let n_candidates = notes_in_range(n_ref, p_offs[0],
     p_offs[p_offs.length - 1],
 					   copy.template[copy.template.length - 1].t_off)
-  
+
   copy.template.forEach((o) => o.n_to = undefined)
   for (var n_cand of n_candidates) {
     let t_off = time_offset(n_cand, n_ref)
@@ -94,4 +94,3 @@ export function do_paste() {
   // Go through each relation, select the corresponding notes, and
   // do_relation()
 }
-

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -96,14 +96,14 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
   }
 
   // Decorate with onclick and onmouseover handlers
-  elem.onclick = function(ev) { toggle_selected(elem, ev.shiftKey) }
-  elem.onmouseover = function (ev) {
-    primaries.forEach((item) => { item.classList.add('extrahover') })
-    secondaries.forEach((item) => { item.classList.add('selecthover') })
+  elem.onclick = () => toggle_selected(elem)
+  elem.onmouseover = function () {
+    primaries.forEach(item => item.classList.add('extrahover'))
+    secondaries.forEach(item => item.classList.add('selecthover'))
   }
-  elem.onmouseout = function (ev) {
-    primaries.forEach((item) => { item.classList.remove('extrahover') })
-    secondaries.forEach((item) => { item.classList.remove('selecthover') })
+  elem.onmouseout = function () {
+    primaries.forEach(item => item.classList.remove('extrahover'))
+    secondaries.forEach(item => item.classList.remove('selecthover'))
   }
   // TODO: Set up more onhover stuff for The Same Relation
   // Elsewhere - but perhaps that's a separate thing?
@@ -187,7 +187,7 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
   }
 
   // Decorate with onclick and onmouseover handlers
-  g_elem.onclick = function(ev) { toggle_selected(g_elem, ev.shiftKey) }
+  g_elem.onclick = () => toggle_selected(g_elem)
   g_elem.onmouseover = function (ev) {
     primaries.forEach((item) => {
       if (item.classList.contains('relation'))

--- a/src/js/new/events/index.js
+++ b/src/js/new/events/index.js
@@ -110,6 +110,7 @@ class EventsManager {
     this.app.ui?.filters?.onChange(e)
     this.app.ui?.mainMenu?.onChange(e)
     this.app.ui?.startScreen?.onChange(e)
+    this.app.ui?.selection?.mode?.onChange(e)
   }
 
   // Forms events
@@ -176,6 +177,13 @@ class EventsManager {
       return this.app.ui.newNote.enable()
     }
 
+    /**
+     * Use primary selection (Shift)
+     */
+    if (isKey(e, 'shift') && pressedModifiers(e).length === 1) {
+      return this.app.ui.selection.mode.set('primary')
+    }
+
     // All shortcuts starting here don’t need modifiers.
 
     if (isModifier(e)) { return }
@@ -194,6 +202,13 @@ class EventsManager {
      */
     if (isKey(e, 'control')) {
       return this.app.ui.newNote.disable()
+    }
+
+    /**
+     * Leave primary selection mode (Shift)
+     */
+    if (isKey(e, 'shift')) {
+      return this.app.ui.selection.mode.set('secondary')
     }
 
     // All shortcuts starting here don’t need modifiers.

--- a/src/js/new/events/keyCodes.js
+++ b/src/js/new/events/keyCodes.js
@@ -1,10 +1,15 @@
 import { arrayIncludesAll } from '../utils/array'
 
 const keys = Object.freeze({
+  shift: 16,
   control: 17,
   escape: 27,
+
+  // arrows
   left: 37,
   right: 39,
+
+  // characters
   a: 65,
   x: 88,
   z: 90,
@@ -25,7 +30,7 @@ export function isModifier(keyboardEvent, modifiers = null) {
 
   // Not requesting a specific modifier.
   if (!modifiers) {
-    return keys !== null // `true` if any modifier is pressed.
+    return !!keys.length // `true` if any modifier is pressed.
   }
 
   // Look for all specified modifiers.
@@ -33,9 +38,10 @@ export function isModifier(keyboardEvent, modifiers = null) {
 }
 
 /**
- * Return pressed modifier keys, or null if none are pressed.
+ * Return pressed modifier keys.
  *
  * @param {KeyboardEvent}
+ * @returns {string[]} modifier keys
  */
 export function pressedModifiers({
   metaKey: meta,
@@ -45,9 +51,7 @@ export function pressedModifiers({
 }) {
   const modifiers = { meta, shift, ctrl, alt }
 
-  const keys = Object.keys(modifiers).filter(key => modifiers[key])
-
-  return keys.length ? keys : null
+  return Object.keys(modifiers).filter(key => modifiers[key])
 }
 
 // The key for usual platform shortcuts (Cmd on macOS, Ctrl anywhere else).

--- a/src/js/new/modules/UI/Selection/index.js
+++ b/src/js/new/modules/UI/Selection/index.js
@@ -4,12 +4,14 @@ import {
   select_visibles
 } from '../../../../ui'
 import SelectionLegend from './legend'
+import SelectionMode from './mode'
 
 class Selection {
   constructor() {
     this.selectBtn = document.getElementById('select-all')
     this.unselectBtn = document.getElementById('unselect-all')
     this.legend = new SelectionLegend() // rename it?
+    this.mode = new SelectionMode() // rename it?
   }
 
   selectAll() {

--- a/src/js/new/modules/UI/Selection/mode.js
+++ b/src/js/new/modules/UI/Selection/mode.js
@@ -1,0 +1,22 @@
+export default class SelectionMode {
+  constructor() {
+    this.primary = document.getElementById('selection-mode-primary')
+    this.secondary = document.getElementById('selection-mode-secondary')
+  }
+
+  set(mode) {
+    this.mode = mode
+    this.updateBtns()
+  }
+
+  // on keypress or radio checked
+  updateBtns() {
+    this[this.mode].checked = true
+  }
+
+  onChange({ target }) {
+    if (target.name == 'selection-mode') {
+      this.set(target.value)
+    }
+  }
+}

--- a/src/js/reductions.js
+++ b/src/js/reductions.js
@@ -20,7 +20,7 @@ export function calc_reduce(mei_graph, remaining_relations, target_relations) {
   ).flat()
   // We know that the remaining relations that have not been
   // selected for reduction will remain
-  remaining_relations = remaining_relations.filter((x) => { return !target_relations.includes(x) })
+  remaining_relations = remaining_relations.filter(x => !target_relations.includes(x))
   // So all of their nodes should be added to the remaining
   // nodes, not just the primaries
   remaining_nodes = remaining_nodes.concat(remaining_relations.map(
@@ -32,12 +32,12 @@ export function calc_reduce(mei_graph, remaining_relations, target_relations) {
     var more_remains = target_relations.filter((he) => {
       // That is, relations that have, as secondaries, nodes
       // we know need to stay
-      return (relation_secondaries(mei_graph, he).findIndex((x) => { return remaining_nodes.includes(x) }) > -1)
+      return (relation_secondaries(mei_graph, he).findIndex(x => remaining_nodes.includes(x)) > -1)
     })
     // Add those relations to the ones that need to stay
     remaining_relations = remaining_relations.concat(more_remains)
     // And remove them from those that may be removed
-    target_relations = target_relations.filter((x) => { return !more_remains.includes(x) })
+    target_relations = target_relations.filter(x => !more_remains.includes(x))
     // And update the remaining nodes
     remaining_nodes = remaining_nodes.concat(more_remains.map(
       (he) => relation_secondaries(mei_graph, he)
@@ -68,7 +68,7 @@ function do_reduce(draw_context, mei_graph, sel, extra) {
     (ge) => get_by_id(mei_graph.getRootNode(), get_id(ge))
   )
 
-  var all_relations_nodes = Array.from(mei_graph.getElementsByTagName('node')).filter((x) => { return x.getAttribute('type') == 'relation' })
+  var all_relations_nodes = Array.from(mei_graph.getElementsByTagName('node')).filter(x => x.getAttribute('type') == 'relation')
 
   var remaining_relations = all_relations_nodes.filter((n) => {
     var g = get_by_id(document, draw_context.id_prefix + n.getAttribute('xml:id'))
@@ -110,11 +110,11 @@ export function undo_reduce(draw_context) {
     return
   }
   // Deselect the current selection, if any
-  selected.forEach(toggle_selected)
-  extraselected.forEach((x) => { toggle_selected(x, true) })
+  selected.forEach(x => toggle_selected(x, false))
+  extraselected.forEach(x => toggle_selected(x, true))
   var [what, elems, sel, extra] = unreduce_actions.pop()
   var [relations, notes, graphicals] = elems
-  graphicals.flat().forEach((x) => { if (x) x.classList.remove('hidden') })
-  sel.forEach((x) => { toggle_selected(x) })
-  extra.forEach((x) => { toggle_selected(x, true) })
+  graphicals.flat().forEach(x => { if (x) x.classList.remove('hidden') })
+  sel.forEach(x => toggle_selected(x, false))
+  extra.forEach(x => toggle_selected(x, true))
 }

--- a/src/js/undo_redo.js
+++ b/src/js/undo_redo.js
@@ -28,9 +28,10 @@ export function do_undo() {
     alert('Cannot undo past a rerender.')
     return
   }
+
   // Deselect the current selection, if any
-  selected.forEach(toggle_selected)
-  extraselected.forEach((x) => { toggle_selected(x, true) })
+  selected.forEach(x => toggle_selected(x, false))
+  extraselected.forEach(x => toggle_selected(x, true))
 
   var draw_contexts = getDrawContexts()
   var redo_actions = getRedoActions()
@@ -53,19 +54,19 @@ export function do_undo() {
       for (const dc of draw_contexts)
         unmark_secondaries(dc, getMeiGraph(), g_elem)
     // Remove added elements
-    added.flat().forEach((x) => {
+    added.flat().forEach(x => {
       if (!node_referred_to(x.getAttribute('xml:id')))
         x.parentNode.removeChild(x)
     })
     // Find and remove any leftover graphical elements
-    Array.from(document.querySelectorAll('[oldid="' + id + '"]')).forEach((x) => x.parentNode.removeChild(x))
+    Array.from(document.querySelectorAll('[oldid="' + id + '"]')).forEach(x => x.parentNode.removeChild(x))
     // Select last selection
-    sel.forEach((x) => { toggle_selected(document.getElementById(x.id)) })
-    extra.forEach((x) => { toggle_selected(document.getElementById(x.id), true) })
+    sel.forEach(x => toggle_selected(document.getElementById(x.id), false))
+    extra.forEach(x => toggle_selected(document.getElementById(x.id), true))
     redo_actions.push([what, [type, id], sel, extra])
   } else if (what == 'delete relation') {
     var removed = elems
-    removed.forEach((x) => {
+    removed.forEach(x => {
       x[1].insertBefore(x[0], x[2])
       let dc = draw_contexts.find((d) => d.svg_elem.contains(x[0]))
       let rel = get_class_from_classlist(x[0]) == 'relation'
@@ -76,8 +77,8 @@ export function do_undo() {
       }
     })
     // Select last selection
-    sel.forEach((x) => { toggle_selected(x) })
-    extra.forEach((x) => { toggle_selected(x, true) })
+    sel.forEach(x => toggle_selected(x, false))
+    extra.forEach(x => toggle_selected(x, true))
     redo_actions.push([what, [], sel, extra])
 
   } else if (what == 'change relation type') {
@@ -94,12 +95,12 @@ export function do_undo() {
       mei_he.getElementsByTagName('label')[0].setAttribute('type', from)
       hes.forEach(toggle_shade)
     })
-    sel.forEach((x) => { toggle_selected(x) })
-    extra.forEach((x) => { toggle_selected(x, true) })
+    sel.forEach(x => toggle_selected(x, false))
+    extra.forEach(x => toggle_selected(x, true))
     redo_actions.push([what, type, sel, extra])
   } else if (what == 'add note') {
     var [mei_elems, graphicals] = elems
-    graphicals.forEach((x) => x.parentNode.removeChild(x))
+    graphicals.forEach(x => x.parentNode.removeChild(x))
     let pname = mei_elems[0].getAttribute('pname')
     let oct = mei_elems[0].getAttribute('oct')
     let id = mei_elems[0].getAttribute('xml:id')
@@ -131,14 +132,14 @@ export function do_redo() {
     return
   }
   // Deselect the current selection, if any
-  selected.forEach(toggle_selected)
-  extraselected.forEach((x) => { toggle_selected(x, true) })
+  selected.forEach(x => toggle_selected(x, false))
+  extraselected.forEach(x => toggle_selected(x, true))
 
   const [what, params, sel, extra] = redo_actions.pop()
 
   // Select the same things that were selected previously
-  sel.forEach((x) => toggle_selected(document.getElementById(x.id)))
-  extra.forEach((x) => { toggle_selected(document.getElementById(x.id), true) })
+  sel.forEach(x => toggle_selected(document.getElementById(x.id), false))
+  extra.forEach(x => toggle_selected(document.getElementById(x.id), true))
 
   let type, id
   switch (what) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -656,7 +656,7 @@ function get_measure(elem) { if (elem.tagName == 'measure') return elem; else re
 // If we have a single note selected, find all other notes of the same
 // pitch in this measure, and select them as secondary, and the previously
 // selected one as primary
-function select_samenote() {
+export function select_samenote() {
   console.debug('Using globals: document, mei to find elems')
   if ((selected.length == 1 || extraselected.length == 1)
    && !(selected.length == 1 && extraselected.length == 1)) {
@@ -706,19 +706,19 @@ function getBoundingBoxTop (elem) {
 
 // Get the Interesting class from a classlist
 export function get_class_from_classlist(elem) {
-  // TODO: If more things can be selected etc., it should be reflected here
-  if (typeof (elem) != 'undefined') {
-    var ci = ''
-    if (elem.classList.contains('note'))
-      ci = 'note'
-    else if (elem.classList.contains('relation'))
-      ci = 'relation'
-    else if (elem.classList.contains('metarelation'))
-      ci = 'metarelation'
-    return ci
-  } else {
+  if (typeof (elem) == 'undefined') {
     return false
   }
+
+  // TODO: If more things can be selected etc., it should be reflected here
+  if (elem.classList.contains('note'))
+    return 'note'
+  if (elem.classList.contains('relation'))
+    return 'relation'
+  if (elem.classList.contains('metarelation'))
+    return 'metarelation'
+
+  return ''
 }
 
 // Get the center of the bounding box

--- a/src/js/visualizations.js
+++ b/src/js/visualizations.js
@@ -128,13 +128,13 @@ export function draw_hierarchy_graph(draw_context, hullPadding = 200, roots_low 
     // Are we running with type-specific shades?
     if (shades)
       toggle_shade(elem)
-    elem.onclick = function(ev) { toggle_selected(elem_in_score, ev.shiftKey) }
+    elem.onclick = ev => toggle_selected(elem_in_score)
 
-    elem.onmouseover = function (ev) {
+    elem.onmouseover = function () {
       elem_in_score.classList.add('relationhover')
       elem_in_score.onmouseover()
     }
-    elem.onmouseout = function (ev) {
+    elem.onmouseout = function () {
       elem_in_score.classList.remove('relationhover')
       elem_in_score.onmouseout()
     }

--- a/src/other-css/style.css
+++ b/src/other-css/style.css
@@ -650,10 +650,7 @@ margin-top: 0.5rem;
   font-size: 300%;
 }
 
-.collapsed #basic_buttons,
-.collapsed #relation_buttons,
-.collapsed #meta_buttons,
-.collapsed #combo_buttons {
+.collapsed #basic_buttons {
   display: none;
 }
 

--- a/src/sass/components/btn/tab-group/_btn.scss
+++ b/src/sass/components/btn/tab-group/_btn.scss
@@ -5,7 +5,6 @@
   --btn-transition: .4s;
 
   position: relative;
-  padding-inline: 1.6rem;
 
   // 1. Remove inner borders
   // 2. Only exterior elements have rounded borders.
@@ -16,35 +15,13 @@
   &:first-child {
     border-start-start-radius: v(btn-default-radius);
     border-end-start-radius: v(btn-default-radius);
-    border-inline-start-width: revert;
+    border-inline-start-width: .2rem; // should be `revert` but it weirdly gives 3px…
   }
 
   &:last-child {
     border-start-end-radius: v(btn-default-radius);
     border-end-end-radius: v(btn-default-radius);
-    border-inline-end-width: revert;
-  }
-
-  // Separator between buttons.
-
-  @include all-but(1) {
-    &::before {
-      content: '';
-      size: .2rem 2rem;
-      position: absolute;
-      left: -.1rem;
-
-      background: $alto;
-      border-radius: .1rem;
-
-      pointer-events: none;
-    }
-  }
-
-
-  &:active {
-    --btn-bg: var(--primary);
-    --btn-color: var(--bg);
+    border-inline-end-width: .2rem;
   }
 
   &[disabled] {

--- a/src/sass/components/btn/tab-group/_ctn.scss
+++ b/src/sass/components/btn/tab-group/_ctn.scss
@@ -2,40 +2,4 @@
 
 .btn-tabs {
   display: inline-flex;
-
-  // When interacting with the group, highlight 1 button, fade out the others.
-
-  &:hover,
-  &:focus,
-  &:focus-within {
-    --btn-transition: .1s;
-
-    .btn-tabs__btn {
-      --btn-border: var(--primary); // overwrite default hover/focus
-
-      // Fade out other buttons.
-
-      &:not(:hover):not(:focus) {
-        --btn-color: #{$alto};
-      }
-
-      /**
-       * Removing transition on background-color and color to only keep the
-       * border-color one gives better feedback on :active release.
-       */
-
-      &:hover,
-      &:focus {
-        transition-property: border-color;
-      }
-
-      // Hide surrounding separators of the active button.
-      &:active {
-        &::before,
-        & + ::before {
-          opacity: 0;
-        }
-      }
-    }
-  }
 }

--- a/src/sass/components/btn/tab-group/_radio.scss
+++ b/src/sass/components/btn/tab-group/_radio.scss
@@ -1,0 +1,36 @@
+.btn-tabs--radio {
+  padding: 0;
+  gap: 0;
+
+  &:focus-within {
+    --btn-border: var(--primary); // overwrite default hover/focus
+    --btn-transition: .1s;
+  }
+}
+
+.btn-tabs__radio {
+  position: absolute;
+  opacity: 0;
+
+  &:checked {
+    + .btn-tabs__accent {
+      --btn-bg: var(--btn-checked, var(--bg));
+      --btn-border: transparent;
+      --btn-color: var(--bg);
+
+      z-index: 1;
+
+      outline: .2rem solid;
+    }
+  }
+}
+
+.btn-tabs__accent {
+  --btn-transition: 0s;
+  --btn-bg: transparent;
+  --btn-border: transparent;
+
+  margin: -.2rem;
+
+  pointer-events: none;
+}

--- a/src/sass/components/btn/tab-group/_tab-group.scss
+++ b/src/sass/components/btn/tab-group/_tab-group.scss
@@ -1,2 +1,0 @@
-@import 'ctn';
-@import 'btn';

--- a/src/sass/components/btn/tab-group/_with-separator.scss
+++ b/src/sass/components/btn/tab-group/_with-separator.scss
@@ -1,0 +1,68 @@
+// Modifier for a group of tab buttons with a separator between them.
+
+.btn-tabs--with-separator {
+  --with-separator: '';
+
+  // When interacting with the group, highlight 1 button, fade out the others.
+
+  &:hover,
+  &:focus,
+  &:focus-within {
+    --btn-transition: .1s;
+
+    .btn-tabs__btn {
+      --btn-border: var(--primary); // overwrite default hover/focus
+
+      // Fade out other buttons.
+
+      &:not(:hover):not(:focus) {
+        --btn-color: #{$alto};
+      }
+
+      /**
+       * Removing transition on background-color and color to only keep the
+       * border-color one gives better feedback on :active release.
+       */
+
+      &:hover,
+      &:focus {
+        transition-property: border-color;
+      }
+
+      // Hide surrounding separators of the active button.
+      &:active {
+        &::before,
+        & + ::before {
+          opacity: 0;
+        }
+      }
+    }
+  }
+
+  // Button
+
+  .btn-tabs__btn {
+    padding-inline: 1.6rem;
+
+    // Separator between buttons.
+
+    @include all-but(1) {
+      &::before {
+        content: v(with-separator, unset);
+        size: .2rem 2rem;
+        position: absolute;
+        left: -.1rem;
+
+        background: $alto;
+        border-radius: .1rem;
+
+        pointer-events: none;
+      }
+    }
+
+    &:active {
+      --btn-bg: var(--primary);
+      --btn-color: var(--bg);
+    }
+  }
+}

--- a/src/sass/components/btn/tab-group/tab-group.scss
+++ b/src/sass/components/btn/tab-group/tab-group.scss
@@ -1,0 +1,4 @@
+@import 'ctn';
+@import 'with-separator';
+@import 'btn';
+@import 'radio';


### PR DESCRIPTION
Closes #166.

Now you can either use the keyboard shortcut (<kbd>shift</kbd>) or the new buttons (radio inputs) to toggle the selection mode.

You can switch from one way to another seamlessly:

https://user-images.githubusercontent.com/9340937/147858034-d985b12a-387c-405f-bd5e-af7d850872eb.mp4

This PR changes a bit the way `toggle_selected(element, extra)` operates.

Before this PR, you could only ask a selection to be _primary_ (`extraselected`) by passing the second parameter with a true-ish value.

With this PR, you don’t need to pass a 2nd parameter (but it remains possible): instead, it checks whether the <kbd>shift</kbd> key is held or not, and it also checks the state of the visual toggle.

For this, I updated the code in a lot of places where `toggle_selected` is used:
- when `event.shiftKey` was used, I simply removed the parameter;
- when it wasn’t used, I checked the context around to decide if the parameter should be removed, set to `true` or `false`, depending on the nature of the selection (secondary, primary, or a concatenation of both).

I think the single place where I’m not sure how it should be is in the [`switch` of `do_redo`](https://github.com/DCMLab/reductive_analysis_app/blob/552d9fe3f7161e5a67111e45fbfa7c498098687a/src/js/undo_redo.js#L163).