### PR TITLE
Fix custom relations registration

### DIFF
--- a/src/js/new/events/index.js
+++ b/src/js/new/events/index.js
@@ -32,7 +32,7 @@ class EventsManager {
     // fields
     document.addEventListener('change', this.onChange.bind(this), captureEvent)
     document.addEventListener('input', this.onInput.bind(this), captureEvent)
-    document.addEventListener('blur', this.onBlur.bind(this), captureEvent)
+    document.addEventListener('submit', this.onSubmit.bind(this), captureEvent)
 
     // core app events
     document.addEventListener('undoredo', this.onUndoRedo.bind(this))
@@ -118,8 +118,8 @@ class EventsManager {
     this.app.ui?.relationWidth?.onInput(e)
   }
 
-  onBlur(e) {
-    this.app.ui?.relations?.onBlur(e)
+  onSubmit(e) {
+    this.app.ui?.relations?.onSubmit(e)
   }
 
   // App custom events

--- a/src/js/new/modules/Score/index.js
+++ b/src/js/new/modules/Score/index.js
@@ -46,8 +46,8 @@ class Score {
     })
   }
 
-  get relationTypes() {
-    return this.#cache.remember('relationTypes', () => {
+  get selectedRelationTypes() {
+    return this.#cache.remember('selectedRelationTypes', () => {
       if (!this.hasSelection || this.selectionType == 'note') { return null }
 
       return new Set(this.flatSelection.map(el => el.getAttribute('type')).filter(type => type))

--- a/src/js/new/modules/UI/Metadata/index.js
+++ b/src/js/new/modules/UI/Metadata/index.js
@@ -7,7 +7,7 @@ import { createField, createRolesFields, createUpdateBtn } from './templates'
 const parser = new DOMParser()
 
 // Assign button id looks like `metadata-something-assign`
-const assignBtnRegex = new RegExp(/^metadata-\w+-assign$/)
+const assignBtnRegex = new RegExp(/^metadata-(\w+)-assign$/)
 
 /**
  * @todo later: evaluate opportunity to move roles to a dedicated module
@@ -49,8 +49,8 @@ class Metadata {
     }
 
     // Update a metadata
-    if (assignBtnRegex.test(target.id)) {
-      const name = target.id.replace('metadata-', '').replace('-assign', '')
+    let name = target.id.match(assignBtnRegex)?.[1]
+    if (name) {
       this.updateScoreMetadata(name)
     }
   }

--- a/src/js/new/modules/UI/Relations/group.js
+++ b/src/js/new/modules/UI/Relations/group.js
@@ -41,9 +41,11 @@ export default class RelationsGroup {
     const btnsTypes = btns.map(btn => btn.dataset.relationName)
     const customTypes = [...types].filter(type => !btnsTypes.includes(type))
 
-    // If there’s exactly 1 custom relation, mark the free field as selected
+    // Mark the free field as selected
+    this.freeFieldCtn.classList.add('fly-out__relationsField--selected')
+
+    // If exactly 1 custom relation is selected, prefill the free field
     if (customTypes.length == 1) {
-      this.freeFieldCtn.classList.add('fly-out__relationsField--selected')
       this.freeField.value = customTypes[0]
     }
   }

--- a/src/js/new/modules/UI/Relations/group.js
+++ b/src/js/new/modules/UI/Relations/group.js
@@ -31,14 +31,32 @@ export default class RelationsGroup {
 
     if (!types) { return }
 
-    Array.from(this.btns)
-      .filter(btn => types.has(btn.dataset.relationName))
-      .forEach(btn => btn.classList.add('btn--selected'))
+    // Mark buttons as selected
+    const btns = Array.from(this.btns).filter(btn => types.has(btn.dataset.relationName))
+    btns.forEach(btn => btn.classList.add('btn--selected'))
+
+    if (types.size <= btns.length) { return }
+
+    // Search for custom relations
+    const btnsTypes = btns.map(btn => btn.dataset.relationName)
+    const customTypes = [...types].filter(type => !btnsTypes.includes(type))
+
+    // If there’s exactly 1 custom relation, mark the free field as selected
+    if (customTypes.length == 1) {
+      this.freeFieldCtn.classList.add('fly-out__relationsField--selected')
+      this.freeField.value = customTypes[0]
+    }
   }
 
   unselect() {
+
+    // Unselect buttons
     Array.from(this.selectedBtns)
       .forEach(btn => btn.classList.remove('btn--selected'))
+
+    // free field
+    this.freeFieldCtn.classList.remove('fly-out__relationsField--selected')
+    this.freeField.value = ''
   }
 
   initHtml(config) {
@@ -67,5 +85,6 @@ export default class RelationsGroup {
     this.btns = this.ctn.getElementsByClassName('btn--relation')
     this.selectedBtns = this.ctn.getElementsByClassName('btn--selected')
     this.freeField = this.ctn.querySelector(`#free-field-${this.type}`)
+    this.freeFieldCtn = this.freeField?.parentElement
   }
 }

--- a/src/js/new/modules/UI/Relations/group.js
+++ b/src/js/new/modules/UI/Relations/group.js
@@ -1,7 +1,6 @@
 import {
   createBtn,
-  createDatalist,
-  createFillable,
+  createDatalistFillable,
   createShowMoreBtn,
   createTitle
 } from './templates'
@@ -57,15 +56,10 @@ export default class RelationsGroup {
 
     btnsHtml = `<div class="btn-group">${btnsHtml}</div>`
 
-    let additionalRelations = ''
-    if ('additional' in config) {
-      additionalRelations +=
-
-        // free field with autocomplete proposals for even more relations…
-        // @Todo: handle this input change events from somewhere…
-        createFillable(this.type, { label: 'Or type a ' + this.name })
-        + createDatalist(config.additional, this.type)
-    }
+    // free field with autocomplete proposals for even more relations…
+    const additionalRelations = 'additional' in config
+      ? createDatalistFillable(config, this.type)
+      : ''
 
     this.ctn = document.getElementById(`${this.type}-btns`)
     this.ctn.innerHTML = titleHtml + btnsHtml + additionalRelations

--- a/src/js/new/modules/UI/Relations/index.js
+++ b/src/js/new/modules/UI/Relations/index.js
@@ -19,7 +19,7 @@ import { DraggableFlyOut } from '../FlyOut'
 import RelationsGroup from './group'
 
 // Assign form id looks like `free-field-something-form`
-const assignFormRegex = new RegExp(/^free-field-\w+-form$/)
+const freeFieldFormRegex = new RegExp(/^free-field-(\w+)-form$/)
 
 class RelationsFlyOut extends DraggableFlyOut {
   constructor() {
@@ -66,16 +66,15 @@ class RelationsFlyOut extends DraggableFlyOut {
   }
 
   onSubmit(e) {
-    const { id } = e.target
+    const relationType = e.target.id.match(freeFieldFormRegex)?.[1]
 
-    if (!assignFormRegex.test(id)) { return }
+    if (!relationType) { return }
 
     e.preventDefault()
 
-    const type = id.replace('free-field-', '').replace('-form', '')
-    const { value } = this[type].freeField
+    const { value } = this[relationType]?.freeField
     if (value) {
-      this[type].eventCallbacks.tap(value)
+      this[relationType].eventCallbacks.tap(value)
     }
   }
 

--- a/src/js/new/modules/UI/Relations/index.js
+++ b/src/js/new/modules/UI/Relations/index.js
@@ -79,11 +79,11 @@ class RelationsFlyOut extends DraggableFlyOut {
   }
 
   onScoreSelection() {
-    const hasSelection = score.hasSelection
+    const { hasSelection, selectionType, selectedRelationTypes } = score
 
     // Update selected buttons.
-    this.relations.select(score.relationTypes)
-    this.metarelations.select(score.relationTypes)
+    this.relations.select(selectionType == 'relation' ? selectedRelationTypes : new Set())
+    this.metarelations.select(selectionType == 'metarelation' ? selectedRelationTypes : new Set())
 
     // Hide if nothing is selected.
     this.toggleVisibility(hasSelection)
@@ -94,17 +94,12 @@ class RelationsFlyOut extends DraggableFlyOut {
     this.relations.show()
 
     // Show metarelations unless a note is selected.
-    this.metarelations.toggleVisibility(score.selectionType != 'note')
-
-    // // selected items are relations or metarelations
-    // if (/relation/.test(score.selectionType)) {
-    //   this[score.selectionType + 's'].show()
-    // }
+    this.metarelations.toggleVisibility(selectionType != 'note')
 
     this.compact()
 
     // Disable the delete button unless a relation is selected.
-    this.deleteBtn.disabled = !hasSelection || score.selectionType == 'note'
+    this.deleteBtn.disabled = !hasSelection || selectionType == 'note'
 
     /**
      * The dimensions of the fly-out may change if the selected item isn’t the

--- a/src/js/new/modules/UI/Relations/index.js
+++ b/src/js/new/modules/UI/Relations/index.js
@@ -18,6 +18,9 @@ import score from '../../Score'
 import { DraggableFlyOut } from '../FlyOut'
 import RelationsGroup from './group'
 
+// Assign form id looks like `free-field-something-form`
+const assignFormRegex = new RegExp(/^free-field-\w+-form$/)
+
 class RelationsFlyOut extends DraggableFlyOut {
   constructor() {
     super('relations-menu')
@@ -62,24 +65,17 @@ class RelationsFlyOut extends DraggableFlyOut {
     }
   }
 
-  onBlur({ target: { dataset, value, id }, target }) {
+  onSubmit(e) {
+    const { id } = e.target
 
-    /**
-     * Early return.
-     *
-     * We can’t directly check `!('relationType' in dataset)` because it
-     * crashes on `document` blur (it has no `dataset`). Two options:
-     * 1. if (!dataset || !('relationType' in dataset))
-     * 2. if (!dataset?.hasOwnProperty('relationType'))
-     *
-     * `hasOwnProperty` is preferred: it allows optional chaining.
-     */
-    if (!dataset?.hasOwnProperty('relationType')) { return }
+    if (!assignFormRegex.test(id)) { return }
 
-    const { relationType } = dataset
+    e.preventDefault()
 
-    if (value && id == `free-field-${relationType}`) {
-      return this[relationType].eventCallbacks.tap(value)
+    const type = id.replace('free-field-', '').replace('-form', '')
+    const { value } = this[type].freeField
+    if (value) {
+      this[type].eventCallbacks.tap(value)
     }
   }
 

--- a/src/js/new/modules/UI/Relations/templates.js
+++ b/src/js/new/modules/UI/Relations/templates.js
@@ -43,7 +43,21 @@ export const createShowMoreBtn = type => `
   </button>
 `
 
-export const createFillable = (id, { label, placeholder = '' }) => `
+export const createDatalistFillable = (config, type) => `
+  <form
+      class="btn-group btn-group--free-field hide-when-compact"
+      id="free-field-${type}-form"
+  >
+      ${createFillable(type, { label: 'Or type a ' + config.name })}
+      ${createDatalist(config.additional, type)}
+
+      <button class="btn btn--plain btn--small">
+          Select <span class="visually-hidden>${type}</span>
+      </button>
+  </form>
+`
+
+const createFillable = (id, { label, placeholder = '' }) => `
   <label
       class="fillable fly-out__relationsField ${CSS.hideIfCompact}"
       for="free-field-${id}"
@@ -66,7 +80,7 @@ export const createFillable = (id, { label, placeholder = '' }) => `
   </label>
 `
 
-export const createDatalist = (types, id) => `
+const createDatalist = (types, id) => `
   <datalist id="datalist-${id}">${createOptions(types)}</datalist>
 `
 

--- a/src/js/new/modules/UI/Relations/templates.js
+++ b/src/js/new/modules/UI/Relations/templates.js
@@ -52,7 +52,7 @@ export const createDatalistFillable = (config, type) => `
       ${createDatalist(config.additional, type)}
 
       <button class="btn btn--plain btn--small">
-          Select <span class="visually-hidden>${type}</span>
+          Assign <span class="visually-hidden>${type}</span>
       </button>
   </form>
 `

--- a/src/sass/_base.scss
+++ b/src/sass/_base.scss
@@ -6,6 +6,7 @@
   --bg: var(--white);
 
   --accent: #{$san-marino};
+  --accent-alt: #{$electric-violet};
 
   --safe-top: var(--safe-area-top, 0);
   --safe-right: var(--safe-area-right, 0);

--- a/src/sass/components/btn/_relations.scss
+++ b/src/sass/components/btn/_relations.scss
@@ -18,6 +18,13 @@
   gap: 1rem 1.5rem;
 }
 
+.btn-group--free-field {
+  flex-wrap: nowrap; // keep the field and the button on the same row
+
+  // avoid stretching the “assign” relation button in the free form field
+  align-items: center;
+}
+
 .btn-group--vertical {
   flex-direction: column;
 }

--- a/src/sass/layout/ui/_relations.scss
+++ b/src/sass/layout/ui/_relations.scss
@@ -21,6 +21,14 @@
   margin: 2rem 0;
 }
 
+// If not focused, make it look a bit like a button when marked as selected.
+.fly-out__relationsField--selected {
+  .fillable__input:not(:focus):not(:hover) {
+    --fillable-border: var(--accent-alt);
+    background: v(fillable-border);
+  }
+}
+
 // Compact mode.
 
 .fly-out--relations-compact {

--- a/src/sass/variables/_colors.scss
+++ b/src/sass/variables/_colors.scss
@@ -28,3 +28,6 @@ $gorse: hsl(54, 100%, 62%);
 $amber: hsl(45, 100%, 51%);
 $orange-peel: hsl(36, 100%, 50%);
 $orange: hsl(14, 100%, 57%);
+
+// Alternative accent
+$electric-violet: hsl(260, 100%, 50%);


### PR DESCRIPTION
Closes #181.

With this PR, we only add the custom relation when hitting <kbd>Enter</kbd> or the new _Assign_ button:

<img width="546" alt="image" src="https://user-images.githubusercontent.com/9340937/149676979-327f14ff-55f6-4aba-a53e-59d0ee4f15b3.png">

Also, it fills the custom field with the name of the selected custom relation, and change its appearance to highlight it as part of the selection. This is only done where there’s exactly **1 selected custom relation**, otherwise it puts an empty string as value. Not sure about it being a decent result; to be evaluated. 🤔

<img width="600" alt="image" src="https://user-images.githubusercontent.com/9340937/149677000-bb6f0970-cc7b-4fdc-af57-15a46aec472c.png">
