### PR TITLE
Xml refactor corresp

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -70,6 +70,7 @@ import {
   add_mei_node_for,
   check_for_duplicate_relations,
   fix_synonyms,
+  fix_corresp,
   get_by_id,
   get_by_oldid,
   get_class_from_classlist,
@@ -395,7 +396,10 @@ function load_finish(loader_modal) {
       return false
     }
   } else {
-    mei = fix_synonyms(mei)
+    // We got a MEI, it could be from a previous version of the app, so we
+    // should fix previous, now deprecated practises, if present.
+    fix_synonyms(mei)
+    fix_corresp(mei.children[0])
   }
 
   try {

--- a/src/js/layers.js
+++ b/src/js/layers.js
@@ -5,10 +5,15 @@ import { clone_mei, get_by_id, get_id, id_in_svg, prefix_ids, note_to_space, cho
 
 // Each layer is represented by a <score> element in the MEI - the
 // surface being the first, and each subsequent layer making up a separate
-// <score> element. Notes that reoccur in analysed layers from the surface
+// <score> element. 
+
+// DEPRECATED: Notes that reoccur in analysed layers from the surface
 // should be connected using @copyof attributes, while the <score> elements
 // could use @sameas to indicate that they represent the same pieces of
 // music, just under different levels of abstraction.
+
+// NEW: Notes and other elements are connected to their more original
+// corresponding elements using the @corresp attribute
 
 function layer_clone_element(changes, elem, new_children) {
   const no_notes_below = new_children.findIndex(
@@ -23,11 +28,15 @@ function layer_clone_element(changes, elem, new_children) {
   if (elem.tagName == 'chord' && no_notes_below)
     return chord_to_space(mei, elem)
   var new_elem = elem.cloneNode()
+  new_elem.setAttribute('corresp', elem.getAttribute('xml:id'))
+// We no longer make a difference between copies and not-copies
+/*
   if (changes) {
     new_elem.setAttribute('corresp', elem.getAttribute('xml:id'))
   } else {
     new_elem.setAttribute('copyof', elem.getAttribute('xml:id'))
   }
+*/
   new_children.forEach((e) => new_elem.appendChild(e))
   return new_elem
 }

--- a/src/js/layers.js
+++ b/src/js/layers.js
@@ -29,8 +29,8 @@ function layer_clone_element(changes, elem, new_children) {
     return chord_to_space(mei, elem)
   var new_elem = elem.cloneNode()
   new_elem.setAttribute('corresp', elem.getAttribute('xml:id'))
-// We no longer make a difference between copies and not-copies
-/*
+  // We no longer make a difference between copies and not-copies
+  /*
   if (changes) {
     new_elem.setAttribute('corresp', elem.getAttribute('xml:id'))
   } else {

--- a/src/js/slicing.js
+++ b/src/js/slicing.js
@@ -13,7 +13,7 @@ import { get_by_id, get_id, note_coords, prefix_ids } from './utils'
 // Add the notes of that slice
 //  by onset (schenkerian)
 //  or by presence, tied (protovoice)
-// Take care when adding to only add one "note" per pitch (use @sameas)
+// Take care when adding to only add one "note" per pitch (use @corresp)
 // Optionally do verticalisations
 function slicify(draw_context, score_elem, tied = false) {
   var vrvToolkit = getVerovioToolkit()

--- a/src/js/trees.js
+++ b/src/js/trees.js
@@ -72,7 +72,7 @@ function obj_tree_to_xml(json_tree) {
   console.log(json_tree.note_id)
   if (json_tree.note_id) {
     var nt = mei.createElement('note')
-    nt.setAttribute('sameas', '#' + json_tree.note_id)
+    nt.setAttribute('corresp', '#' + json_tree.note_id)
     lbl.appendChild(nt)
   }
 
@@ -107,9 +107,9 @@ function xml_subtree_to_obj(elem) {
     'label': lbl.textContent,
   }
   if (lbl.children.length != 0) {
-    // Assume our structure - any label child is a note sameas
+    // Assume our structure - any label child is a note corresp
     // TODO: fix, obviously
-    obj.note_id = lbl.querySelector('note').getAttribute('sameas').replace('#', '')
+    obj.note_id = lbl.querySelector('note').getAttribute('corresp').replace('#', '')
   }
   var chlds = Array.from(elem.children)
   chlds.shift() // Get rid of the label

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -403,7 +403,7 @@ export function node_referred_to(id) {
 function node_to_note_id_layer(layer_context, node) {
   var id = node.getElementsByTagName('label')[0].
     getElementsByTagName('note')[0].
-    getAttribute('sameas')
+    getAttribute('corresp')
   var pair = layer_context.id_mapping.find((x) => ('#' + x[1]) == id)
   if (pair)
     return pair[0]
@@ -424,7 +424,7 @@ function node_to_note_id_drawn(draw_context, note) {
 function node_to_note_id_prefix(prefix, note) {
   return note.getElementsByTagName('label')[0].
     getElementsByTagName('note')[0].
-    getAttribute('sameas').replace('#', '#' + prefix)
+    getAttribute('corresp').replace('#', '#' + prefix)
 }
 
 // From MEI graph node to the ID string for its referred note.
@@ -433,7 +433,7 @@ export function node_to_note_id(note) {
     return note.getAttribute('xml:id')
   return note.getElementsByTagName('label')[0].
     getElementsByTagName('note')[0].
-    getAttribute('sameas').replace('#', '')
+    getAttribute('corresp').replace('#', '')
 }
 
 // Always-positive modulo
@@ -558,7 +558,7 @@ export function add_mei_node_for(mei_graph, note) {
   // This node represent that note
   var label = mei_graph.getRootNode().createElement('label')
   var note = mei_graph.getRootNode().createElement('note')
-  note.setAttribute('sameas', '#' + id)
+  note.setAttribute('corresp', '#' + id)
   elem.appendChild(label)
   label.appendChild(note)
   // But should have a separate XML ID
@@ -764,7 +764,7 @@ function is_empty_relation(elem) {
 // Are we looking a a single note?
 function is_note_node(elem) {
   notes = elem.getElementsByTagName('note')
-  return elem.tagName = 'node' && notes.length == 1 && notes[0].getAttribute('sameas')
+  return elem.tagName == 'node' && notes.length == 1 && notes[0].getAttribute('corresp')
 }
 
 // Clean up in the graph to remove empty relations
@@ -910,7 +910,7 @@ export function prefix_ids(elem, prefix) {
   if (elem.getAttribute('xml:id')) {
     // MEI modification
     // No need to set oldid - we have already made links using
-    // copyof/sameas
+    // corresp
     elem.setAttribute('xml:id', prefix + elem.getAttribute('xml:id'))
   }
   if (elem.getAttribute('startid'))

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -818,29 +818,28 @@ export function fix_synonyms(mei) {
 
 // sameas/copyof for layers and graphs is deprecated, all should be corresp
 export function fix_corresp(mei_elem) {
-  Array.from(mei_elem.children).forEach(fix_corresp) //recurse
+  Array.from(mei_elem.children).forEach(fix_corresp) // recurse
   let attr = mei_elem.hasAttribute('sameas') ? 'sameas' :
-             mei_elem.hasAttribute('copyof') ? 'copyof' : ''
-  if(attr){
-    if(mei_elem.closest('graph') || mei_elem.closest('eTree')){
+    mei_elem.hasAttribute('copyof') ? 'copyof' : ''
+  if (attr) {
+    if (mei_elem.closest('graph') || mei_elem.closest('eTree')) {
       // We're in the analysis, any sameas/copyof should be a corresp
       mei_elem.setAttribute('corresp', mei_elem.getAttribute(attr))
       mei_elem.removeAttribute(attr)
-    }else{
+    } else {
       // We're in a score
       let target = get_by_id(mei, mei_elem.getAttribute(attr))
-      if(target.closest('score') != mei_elem.closest('score')){
-	// TODO: Bump this check another level up (to <mdiv>) once the change
-	// goes through that that's where layers live
-	// We're referring outside the score, this is probably another layer
-	mei_elem.setAttribute('corresp', mei_elem.getAttribute(attr))
-	mei_elem.removeAttribute(attr)
+      if (target.closest('score') != mei_elem.closest('score')) {
+        // TODO: Bump this check another level up (to <mdiv>) once the change
+        // goes through that that's where layers live
+        // We're referring outside the score, this is probably another layer
+        mei_elem.setAttribute('corresp', mei_elem.getAttribute(attr))
+        mei_elem.removeAttribute(attr)
       }
     }
     // Probably a legit use of sameas/copyof
   }
 }
-
 
 var attributes = ['dur',
   'n',

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -816,6 +816,32 @@ export function fix_synonyms(mei) {
   return mei
 }
 
+// sameas/copyof for layers and graphs is deprecated, all should be corresp
+export function fix_corresp(mei_elem) {
+  Array.from(mei_elem.children).forEach(fix_corresp) //recurse
+  let attr = mei_elem.hasAttribute('sameas') ? 'sameas' :
+             mei_elem.hasAttribute('copyof') ? 'copyof' : ''
+  if(attr){
+    if(mei_elem.closest('graph') || mei_elem.closest('eTree')){
+      // We're in the analysis, any sameas/copyof should be a corresp
+      mei_elem.setAttribute('corresp', mei_elem.getAttribute(attr))
+      mei_elem.removeAttribute(attr)
+    }else{
+      // We're in a score
+      let target = get_by_id(mei, mei_elem.getAttribute(attr))
+      if(target.closest('score') != mei_elem.closest('score')){
+	// TODO: Bump this check another level up (to <mdiv>) once the change
+	// goes through that that's where layers live
+	// We're referring outside the score, this is probably another layer
+	mei_elem.setAttribute('corresp', mei_elem.getAttribute(attr))
+	mei_elem.removeAttribute(attr)
+      }
+    }
+    // Probably a legit use of sameas/copyof
+  }
+}
+
+
 var attributes = ['dur',
   'n',
   'dots',


### PR DESCRIPTION
This changes the behaviour of the app to use `@corresp` attributes instead of `@sameas/@copyof` in both layers and analyses, and adds a function to fix files created with the old method. This fixes #162 .