### PR TITLE
Prepend license to every relevant file.

### DIFF
--- a/.github/workflows/js-action-template.yml
+++ b/.github/workflows/js-action-template.yml
@@ -1,0 +1,9 @@
+on: workflow_dispatch
+
+jobs:
+    prepend_license:
+        runs-on: ubuntu-latest
+        name: Prepend license to every relevant file.
+        steps:
+            - uses: actions/checkout@v2
+            - uses: DCMLab/add-file-header-action@v1

--- a/.header-config.json
+++ b/.header-config.json
@@ -1,0 +1,35 @@
+{
+    "srcFolders": ["./"],
+    "rules": [
+        {
+            "match": [".*\\.html"],
+            "skipIfContains": "MuseReduce is free software",
+            "comments": {
+                "start": "<!--",
+                "line": "   ~ ",
+                "end": "-->"
+            },
+            "content": "default_license_header.txt"
+        },
+        {
+            "match": [".*\\.js"],
+            "skipIfContains": "MuseReduce is free software",
+            "comments": {
+                "start": "/*",
+                "line": "   ~ ",
+                "end": "*/"
+            },
+            "content": "default_license_header.txt"
+        },
+        {
+            "match": [".*\\.scss"],
+            "skipIfContains": "MuseReduce is free software",
+            "comments": {
+                "start": "/*",
+                "line": "   ~ ",
+                "end": "*/"
+            },
+            "content": "default_license_header.txt"
+        }
+    ]
+}

--- a/default_license_header.txt
+++ b/default_license_header.txt
@@ -1,0 +1,10 @@
+=====
+This file is part of MuseReduce, a webapp for graph-based music analysis.
+Copyright (c) 2022  Petter Ericson, Yannis Rammos, Mehdi Mehra et al.
+
+MuseReduce is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation.
+
+MuseReduce is distributed without any warranty. See the GNU Affero General Public License for more details.
+
+https://www.gnu.org/licenses/agpl-3.0.en.html
+=====


### PR DESCRIPTION
This is proposed as a manually executed GitHub action for now. Once mature, it can be modified to run on each push or merge operation.