### PR TITLE
fix: delete parent meta-relation if needed and support undo

### DIFF
--- a/src/js/delete.js
+++ b/src/js/delete.js
@@ -5,8 +5,6 @@ Copyright (C) 2022  Petter Ericson, Yannis Rammos, Mehdi Merah, and the EPFL Dig
 
 MuseReduce is free software: you can redistribute it and/or modify it under the terms of the Affero General Public License as published by the Free Software Foundation. MuseReduce is distributed without explicit or implicit warranty. See the Affero General Public License at https://www.gnu.org/licenses/agpl-3.0.en.html for more details.
 */
-import $ from 'jquery'
-
 import { getDrawContexts, getMeiGraph, getUndoActions } from './app'
 import { toggle_selected } from './ui'
 import { flush_redo } from './undo_redo'
@@ -16,37 +14,52 @@ function delete_relation(elem) {
   console.debug('Using globals: mei for element selection')
   // Assume no meta-edges for now, meaning we only have to
   // remove the SVG elem, the MEI node, and any involved arcs
-  var mei_id = get_id(elem)
-  var mei_he = get_by_id(mei, mei_id)
-  var svg_hes = []
-  var metarel = get_class_from_classlist(elem) == 'metarelation'
-  var mei_graph = getMeiGraph()
-  var draw_contexts = getDrawContexts()
+  const mei_id = get_id(elem)
+  const mei_he = get_by_id(mei, mei_id)
+  const svg_hes = []
+  const is_meta_relation = get_class_from_classlist(elem) == 'metarelation'
+  const mei_graph = getMeiGraph()
+  const draw_contexts = getDrawContexts()
   for (const draw_context of draw_contexts) {
-    let svg_he = get_by_id(document, draw_context.id_prefix + mei_id)
+    const svg_he = get_by_id(document, draw_context.id_prefix + mei_id)
     if (svg_he) {
       svg_hes.push(svg_he)
-      if (!metarel)
-        unmark_secondaries(draw_context, mei_graph, mei_he)
+      if (!is_meta_relation) unmark_secondaries(draw_context, mei_graph, mei_he)
     }
   }
 
+  // Find all arcs related to this element
   var arcs =
     Array.from(mei.getElementsByTagName('arc')).filter((arc) => {
       return arc.getAttribute('to') == '#' + elem.id ||
               arc.getAttribute('from') == '#' + elem.id
     })
-  var removed = arcs.concat(svg_hes)
+  // Find meta-relations associated with this relation
+  let meta_relations = []
+  let meta_relation_arcs = []
+
+  // Only find meta-relations if this is not a meta-relation itself
+  if (!is_meta_relation) {
+    const result = find_parent_meta_relations(elem, mei, draw_contexts, svg_hes)
+    meta_relations = result.meta_relations
+    meta_relation_arcs = result.meta_relation_arcs
+  }
+
+  // Combine all elements that need to be removed
+  let removed = arcs.concat(svg_hes).concat(meta_relations).concat(meta_relation_arcs)
   removed.push(mei_he)
-  var action_removed = removed.map((x) => {
-    var elems = [x, x.parentElement, x.nextSibling]
+
+  // Remove duplicates (in case some elements are counted twice)
+  removed = [...new Set(removed)]
+
+  const action_removed = removed.map(x => {
+    const elems = [x, x.parentElement, x.nextSibling]
     // If x corresponds to an SVG note (try!), un-style it as if we were not hovering over the relation.
     // This is necessary when deleting via they keyboard (therefore while hovering).
     try {
       const element = document.querySelector(`g #${x.getAttribute('to').substring(4)}`)
       element.setAttribute('class', 'note')
-    } catch (e) {
-    }
+    } catch (e) {}
     x.parentElement.removeChild(x)
     return elems
   })
@@ -70,4 +83,61 @@ export function delete_relations(redoing = false) {
   sel.forEach(toggle_selected)
   if (!redoing)
     flush_redo()
+}
+
+/**
+ * Finds all meta-relations that reference a specific relation element, along with their
+ * visual representations and connecting arcs.
+ *
+ * When a relation is deleted, any meta-relations that reference it should also be deleted.
+ * This function identifies all such meta-relations and their associated elements.
+ *
+ * @param {Element} elem - The target relation element being deleted
+ * @param {Document} mei - The MEI document containing the graph data
+ * @param {Array} draw_contexts - The drawing contexts containing SVG representations
+ * @param {Array} svg_hes - Array of SVG elements (this is modified by adding meta-relation SVGs)
+ *
+ * @returns {Object} An object containing:
+ *   - meta_relations: Array of MEI meta-relation nodes that reference the relation
+ *   - meta_relation_arcs: Array of arcs connecting these meta-relations
+ */
+function find_parent_meta_relations(elem, mei, draw_contexts, svg_hes) {
+  let meta_relations = []
+  let meta_relation_arcs = []
+
+  // Find arcs that connect meta-relations to this relation
+  const meta_arcs = Array.from(mei.getElementsByTagName('arc')).filter(
+    arc => arc.getAttribute('to') == '#' + elem.id || arc.getAttribute('from') == '#' + elem.id
+  )
+
+  // For each arc, find the meta-relation nodes
+  meta_arcs.forEach(arc => {
+    // Find the meta-relation (whether it's at the "to" or "from" end)
+    const meta_id =
+      arc.getAttribute('to') === '#' + elem.id
+        ? arc.getAttribute('from').substring(1)
+        : arc.getAttribute('to').substring(1)
+
+    const meta_node = get_by_id(mei, meta_id)
+    if (meta_node && meta_node.getAttribute('type') === 'metarelation') {
+      meta_relations.push(meta_node)
+
+      // Find SVG elements for this meta-relation
+      for (const draw_context of draw_contexts) {
+        let svg_meta = get_by_id(document, draw_context.id_prefix + meta_id)
+        if (svg_meta) {
+          svg_hes.push(svg_meta)
+        }
+      }
+
+      // Find all arcs related to this meta-relation
+      const related_arcs = Array.from(mei.getElementsByTagName('arc')).filter(
+        a => a.getAttribute('to') == '#' + meta_id || a.getAttribute('from') == '#' + meta_id
+      )
+
+      meta_relation_arcs = meta_relation_arcs.concat(related_arcs)
+    }
+  })
+
+  return { meta_relations, meta_relation_arcs }
 }


### PR DESCRIPTION
- Added `find_parent_meta_relation`
- Rename `metarel` to `is_meta_relation`
- Use `let` and `const` instead of `var` for best practice

refs: #63