### PR TITLE
fix: update hierarchy tree on editing relation

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -11,9 +11,6 @@ import '/sass/app.scss'
 
 import $ from 'jquery'
 
-import { action_conf } from './conf'
-import { navigation_conf } from './conf'
-import { custom_conf } from './conf'
 import { debug } from './conf'
 
 import newApp from './new/app'
@@ -202,6 +199,9 @@ export function do_relation(type, id, redoing = false) {
   }
   if (!redoing)
     flush_redo()
+
+  // Update hierarchy tree if visible
+  window.relationTreeInstance?.updateIfVisible()
 }
 
 export function do_comborelation(type) {
@@ -221,6 +221,9 @@ export function do_comborelation(type) {
   selected = all
 
   do_relation(comboRelationTypes.main[type].total)
+
+  // Update hierarchy tree if visible
+  window.relationTreeInstance?.updateIfVisible()
 }
 
 export function do_metarelation(type, id, redoing = false) {
@@ -249,6 +252,9 @@ export function do_metarelation(type, id, redoing = false) {
   selected.concat(extraselected).forEach(toggle_selected) // De-select
   if (!redoing)
     flush_redo()
+
+  // Update hierarchy tree if visible
+  window.relationTreeInstance?.updateIfVisible()
 }
 
 var rerendered_after_action

--- a/src/js/delete.js
+++ b/src/js/delete.js
@@ -77,6 +77,9 @@ export function delete_relations(redoing = false) {
   sel.forEach(toggle_selected)
   if (!redoing)
     flush_redo()
+
+  // Update hierarchy tree if visible
+  window.relationTreeInstance?.updateIfVisible()
 }
 
 /**

--- a/src/js/delete.js
+++ b/src/js/delete.js
@@ -35,15 +35,9 @@ function delete_relation(elem) {
               arc.getAttribute('from') == '#' + elem.id
     })
   // Find meta-relations associated with this relation
-  let meta_relations = []
-  let meta_relation_arcs = []
-
-  // Only find meta-relations if this is not a meta-relation itself
-  if (!is_meta_relation) {
-    const result = find_parent_meta_relations(elem, mei, draw_contexts, svg_hes)
-    meta_relations = result.meta_relations
-    meta_relation_arcs = result.meta_relation_arcs
-  }
+  const result = find_all_parent_relations(elem, mei, draw_contexts, svg_hes)
+  const meta_relations = result.meta_relations
+  const meta_relation_arcs = result.meta_relation_arcs
 
   // Combine all elements that need to be removed
   let removed = arcs.concat(svg_hes).concat(meta_relations).concat(meta_relation_arcs)
@@ -90,35 +84,44 @@ export function delete_relations(redoing = false) {
  * visual representations and connecting arcs.
  *
  * When a relation is deleted, any meta-relations that reference it should also be deleted.
- * This function identifies all such meta-relations and their associated elements.
+ * This function recursively identifies all such parent relations (parents, grandparents, etc.)
+ * and their associated elements.
  *
  * @param {Element} elem - The target relation element being deleted
  * @param {Document} mei - The MEI document containing the graph data
  * @param {Array} draw_contexts - The drawing contexts containing SVG representations
  * @param {Array} svg_hes - Array of SVG elements (this is modified by adding meta-relation SVGs)
+ * @param {Set} [processedIds=new Set()] - Set of already processed meta-relation IDs to prevent infinite recursion
  *
  * @returns {Object} An object containing:
  *   - meta_relations: Array of MEI meta-relation nodes that reference the relation
  *   - meta_relation_arcs: Array of arcs connecting these meta-relations
  */
-function find_parent_meta_relations(elem, mei, draw_contexts, svg_hes) {
+function find_all_parent_relations(elem, mei, draw_contexts, svg_hes, processedIds = new Set()) {
   let meta_relations = []
   let meta_relation_arcs = []
 
+  const elemId = elem.id || get_id(elem)
+
   // Find arcs that connect meta-relations to this relation
+  // Only look for arcs where this element is the target (to) - parent->child
   const meta_arcs = Array.from(mei.getElementsByTagName('arc')).filter(
-    arc => arc.getAttribute('to') == '#' + elem.id || arc.getAttribute('from') == '#' + elem.id
+    arc => arc.getAttribute('to') == '#' + elemId
   )
 
-  // For each arc, find the meta-relation nodes
+  // For each arc, find the meta-relation nodes that are parents of this element
   meta_arcs.forEach(arc => {
-    // Find the meta-relation (whether it's at the "to" or "from" end)
-    const meta_id =
-      arc.getAttribute('to') === '#' + elem.id
-        ? arc.getAttribute('from').substring(1)
-        : arc.getAttribute('to').substring(1)
+    // The source of the arc is the parent meta-relation
+    const meta_id = arc.getAttribute('from').substring(1)
 
+    // Skip if already processed
+    if (processedIds.has(meta_id)) {
+      return
+    }
+
+    processedIds.add(meta_id)
     const meta_node = get_by_id(mei, meta_id)
+
     if (meta_node && meta_node.getAttribute('type') === 'metarelation') {
       meta_relations.push(meta_node)
 
@@ -136,6 +139,19 @@ function find_parent_meta_relations(elem, mei, draw_contexts, svg_hes) {
       )
 
       meta_relation_arcs = meta_relation_arcs.concat(related_arcs)
+
+      // Recursively find parent meta-relations of this meta-relation
+      const result = find_all_parent_relations(
+        { id: meta_id },
+        mei,
+        draw_contexts,
+        svg_hes,
+        processedIds
+      )
+
+      // Merge results
+      meta_relations = meta_relations.concat(result.meta_relations)
+      meta_relation_arcs = meta_relation_arcs.concat(result.meta_relation_arcs)
     }
   })
 

--- a/src/js/delete.js
+++ b/src/js/delete.js
@@ -5,8 +5,6 @@ Copyright (C) 2022  Petter Ericson, Yannis Rammos, Mehdi Merah, and the EPFL Dig
 
 MuseReduce is free software: you can redistribute it and/or modify it under the terms of the Affero General Public License as published by the Free Software Foundation. MuseReduce is distributed without explicit or implicit warranty. See the Affero General Public License at https://www.gnu.org/licenses/agpl-3.0.en.html for more details.
 */
-import $ from 'jquery'
-
 import { getDrawContexts, getMeiGraph, getUndoActions } from './app'
 import { toggle_selected } from './ui'
 import { flush_redo } from './undo_redo'
@@ -16,37 +14,52 @@ function delete_relation(elem) {
   console.debug('Using globals: mei for element selection')
   // Assume no meta-edges for now, meaning we only have to
   // remove the SVG elem, the MEI node, and any involved arcs
-  var mei_id = get_id(elem)
-  var mei_he = get_by_id(mei, mei_id)
-  var svg_hes = []
-  var metarel = get_class_from_classlist(elem) == 'metarelation'
-  var mei_graph = getMeiGraph()
-  var draw_contexts = getDrawContexts()
+  const mei_id = get_id(elem)
+  const mei_he = get_by_id(mei, mei_id)
+  const svg_hes = []
+  const is_meta_relation = get_class_from_classlist(elem) == 'metarelation'
+  const mei_graph = getMeiGraph()
+  const draw_contexts = getDrawContexts()
   for (const draw_context of draw_contexts) {
-    let svg_he = get_by_id(document, draw_context.id_prefix + mei_id)
+    const svg_he = get_by_id(document, draw_context.id_prefix + mei_id)
     if (svg_he) {
       svg_hes.push(svg_he)
-      if (!metarel)
-        unmark_secondaries(draw_context, mei_graph, mei_he)
+      if (!is_meta_relation) unmark_secondaries(draw_context, mei_graph, mei_he)
     }
   }
 
+  // Find all arcs related to this element
   var arcs =
     Array.from(mei.getElementsByTagName('arc')).filter((arc) => {
       return arc.getAttribute('to') == '#' + elem.id ||
               arc.getAttribute('from') == '#' + elem.id
     })
-  var removed = arcs.concat(svg_hes)
+  // Find meta-relations associated with this relation
+  let meta_relations = []
+  let meta_relation_arcs = []
+
+  // Only find meta-relations if this is not a meta-relation itself
+  if (!is_meta_relation) {
+    const result = find_parent_meta_relations(elem, mei, draw_contexts, svg_hes)
+    meta_relations = result.meta_relations
+    meta_relation_arcs = result.meta_relation_arcs
+  }
+
+  // Combine all elements that need to be removed
+  let removed = arcs.concat(svg_hes).concat(meta_relations).concat(meta_relation_arcs)
   removed.push(mei_he)
-  var action_removed = removed.map((x) => {
-    var elems = [x, x.parentElement, x.nextSibling]
+
+  // Remove duplicates (in case some elements are counted twice)
+  removed = [...new Set(removed)]
+
+  const action_removed = removed.map(x => {
+    const elems = [x, x.parentElement, x.nextSibling]
     // If x corresponds to an SVG note (try!), un-style it as if we were not hovering over the relation.
     // This is necessary when deleting via they keyboard (therefore while hovering).
     try {
       const element = document.querySelector(`g #${x.getAttribute('to').substring(4)}`)
       element.setAttribute('class', 'note')
-    } catch (e) {
-    }
+    } catch (e) {}
     x.parentElement.removeChild(x)
     return elems
   })
@@ -70,4 +83,61 @@ export function delete_relations(redoing = false) {
   sel.forEach(toggle_selected)
   if (!redoing)
     flush_redo()
+}
+
+/**
+ * Finds all meta-relations that reference a specific relation element, along with their
+ * visual representations and connecting arcs.
+ *
+ * When a relation is deleted, any meta-relations that reference it should also be deleted.
+ * This function identifies all such meta-relations and their associated elements.
+ *
+ * @param {Element} elem - The target relation element being deleted
+ * @param {Document} mei - The MEI document containing the graph data
+ * @param {Array} draw_contexts - The drawing contexts containing SVG representations
+ * @param {Array} svg_hes - Array of SVG elements (this is modified by adding meta-relation SVGs)
+ *
+ * @returns {Object} An object containing:
+ *   - meta_relations: Array of MEI meta-relation nodes that reference the relation
+ *   - meta_relation_arcs: Array of arcs connecting these meta-relations
+ */
+function find_parent_meta_relations(elem, mei, draw_contexts, svg_hes) {
+  let meta_relations = []
+  let meta_relation_arcs = []
+
+  // Find arcs that connect meta-relations to this relation
+  const meta_arcs = Array.from(mei.getElementsByTagName('arc')).filter(
+    arc => arc.getAttribute('to') == '#' + elem.id || arc.getAttribute('from') == '#' + elem.id
+  )
+
+  // For each arc, find the meta-relation nodes
+  meta_arcs.forEach(arc => {
+    // Find the meta-relation (whether it's at the "to" or "from" end)
+    const meta_id =
+      arc.getAttribute('to') === '#' + elem.id
+        ? arc.getAttribute('from').substring(1)
+        : arc.getAttribute('to').substring(1)
+
+    const meta_node = get_by_id(mei, meta_id)
+    if (meta_node && meta_node.getAttribute('type') === 'metarelation') {
+      meta_relations.push(meta_node)
+
+      // Find SVG elements for this meta-relation
+      for (const draw_context of draw_contexts) {
+        let svg_meta = get_by_id(document, draw_context.id_prefix + meta_id)
+        if (svg_meta) {
+          svg_hes.push(svg_meta)
+        }
+      }
+
+      // Find all arcs related to this meta-relation
+      const related_arcs = Array.from(mei.getElementsByTagName('arc')).filter(
+        a => a.getAttribute('to') == '#' + meta_id || a.getAttribute('from') == '#' + meta_id
+      )
+
+      meta_relation_arcs = meta_relation_arcs.concat(related_arcs)
+    }
+  })
+
+  return { meta_relations, meta_relation_arcs }
 }

--- a/src/js/new/modules/UI/Layers/relationsTree.js
+++ b/src/js/new/modules/UI/Layers/relationsTree.js
@@ -11,6 +11,11 @@ export default class RelationsTree {
 
     this.visible = false
     this.shouldDrawRootsLow = false
+
+    // Register this instance to make it accessible globally
+    if (!window.relationTreeInstance) {
+      window.relationTreeInstance = this
+    }
   }
 
   /**
@@ -26,9 +31,17 @@ export default class RelationsTree {
     }
   }
 
+  /**
+   * Update the hierarchy tree if it's currently visible
+   * This can be called from anywhere in the application
+   */
+  updateIfVisible() {
+    if (!this.visible) return
+    this.draw()
+  }
+
   onChange({ target }) {
     if (target.name == 'relations-tree') {
-      console.log(getCurrentDrawContext())
       this.visible = target.value == 'on'
       this.draw()
     }
@@ -49,5 +62,8 @@ export default class RelationsTree {
     console.log(hasTree)
 
     this[hasTree ? 'on' : 'off'].checked = true
+    if (hasTree) {
+      this.visible = true
+    }
   }
 }

--- a/src/js/undo_redo.js
+++ b/src/js/undo_redo.js
@@ -74,7 +74,14 @@ export function do_undo() {
   } else if (what == 'delete relation') {
     var removed = elems
     removed.forEach(x => {
-      x[1].insertBefore(x[0], x[2])
+      // Check if reference node is still valid before inserting
+      if (x[2] && x[1].contains(x[2])) {
+        x[1].insertBefore(x[0], x[2])
+      } else {
+        // Append if reference node is invalid or missing
+        x[1].appendChild(x[0])
+      }
+
       let dc = draw_contexts.find((d) => d.svg_elem.contains(x[0]))
       let rel = get_class_from_classlist(x[0]) == 'relation'
       if (dc && rel) {

--- a/src/js/undo_redo.js
+++ b/src/js/undo_redo.js
@@ -71,6 +71,9 @@ export function do_undo() {
     sel.forEach(x => toggle_selected(document.getElementById(x.id), false))
     extra.forEach(x => toggle_selected(document.getElementById(x.id), true))
     redo_actions.push([what, [type, id], sel, extra])
+
+    // Update hierarchy tree if visible
+    window.relationTreeInstance?.updateIfVisible()
   } else if (what == 'delete relation') {
     var removed = elems
     removed.forEach(x => {
@@ -95,6 +98,8 @@ export function do_undo() {
     extra.forEach(x => toggle_selected(x, true))
     redo_actions.push([what, [], sel, extra])
 
+    // Update hierarchy tree if visible
+    window.relationTreeInstance?.updateIfVisible()
   } else if (what == 'change relation type') {
     var types = elems
     let type = elems[0][1]
@@ -112,6 +117,9 @@ export function do_undo() {
     sel.forEach(x => toggle_selected(x, false))
     extra.forEach(x => toggle_selected(x, true))
     redo_actions.push([what, type, sel, extra])
+
+    // Update hierarchy tree if visible
+    window.relationTreeInstance?.updateIfVisible()
   } else if (what == 'add note') {
     var [mei_elems, graphicals] = elems
     graphicals.forEach(x => x.parentNode.removeChild(x))


### PR DESCRIPTION
- Makes the RelationsTree instance globally accessible via `window.relationTreeInstance`
- Added hierarchy tree updates on creating and deleting relations

closes: https://github.com/DCMLab/reductive_analysis_app/issues/234