### PR TITLE
fix: add filename to file menu and tab title

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -163,7 +163,10 @@
                 </h3>
 
                 <div class="fly-out__inner">
-                    <h4 class="fly-out__title">File</h4>
+                    <h4 class="fly-out__title">File:
+                        <span class="fly-out__title" id="menu-filename"></span>
+                    </h4>
+
 
                     <div class="btn-group">
                         <button id="save-file" class="btn btn--plain btn--small" type="button">Save file</button>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -354,8 +354,11 @@ export function load(event) {
      * move this to the MAIN MENU
      */
     filename = files[0].name.split('.').slice(0, -1).join('.')
-    if (filename == '')
-      filename = files[0].name
+    if (filename == '') filename = files[0].name
+
+    // Update page title and menu filename
+    document.title = `${filename}`
+    document.getElementById('menu-filename').textContent = filename
   }
 }
 

--- a/src/sass/components/fly-out/_elements.scss
+++ b/src/sass/components/fly-out/_elements.scss
@@ -34,7 +34,7 @@
 }
 
 .fly-out__title {
-  margin: 1rem 0;
+  margin-bottom: 2rem;
 }
 
 .fly-out__title--big {


### PR DESCRIPTION
refs: #196

example:
![image](https://github.com/user-attachments/assets/fa250a4f-2f0b-4b38-a769-35372a00cc59)
