### PR TITLE
style: use Verovio options for note color

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -638,7 +638,8 @@ function render_mei(mei) {
   var svg = vrvToolkit.renderData(data, {
     pageWidth: 20000,
     pageHeight: 10000,
-    breaks: 'none'
+    breaks: 'none',
+    svgCss: 'g.notehead, g.stem, g.dots {fill: currentColor;}',
   })
   return [data, svg]
 }

--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -305,33 +305,28 @@ body:not(.mousedown) .note:hover {
        filter: url("#glowFilter");
 }
 
-.note {
-stroke-opacity: 0;
-stroke-width: 150;
-stroke: black;
-}
-
-
 .extraselectednote {
-    fill: red;
+    color: red;
 }
 .selectednote {
-    fill: green;
+  color: green;
 }
 .extrahover {
       transform: translate3d(0,0,0);
        filter: url("#extraFilter");
-      fill: red;
+       color: red;
 }
 .selecthover {
       transform: translate3d(0,0,0);
        filter: url("#selectFilter");
 }
 .secondarynote {
-  fill-opacity: calc(1.0 / var(--how-secondary));
+  opacity: calc(1.0 / var(--how-secondary));
 }
 
-
+.secondarynote .stem path {
+  stroke-opacity: calc(1.0 / var(--how-secondary));
+}
 
 .relation,
 .metarelation {

--- a/src/sass/components/selection/selection.scss
+++ b/src/sass/components/selection/selection.scss
@@ -57,5 +57,5 @@
 // }
 
 .selectednote {
-  fill: #1890ff;
+  color: #1890ff;
 }


### PR DESCRIPTION
- Removed unnecessary styles for `.note`
- Added global styles using verovio options and change note color using `color`

refs: #257