### PR TITLE
Make default window title less verbose.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
 
 <head>
     <meta charset="UTF-8">
-    <title>DCML Reductive Analysis Webapp / Redusic / MuseReduce</title>
+    <title>Reductive Analysis App</title>
     <!-- <meta name="description" content="To be completed"> -->
     <!-- <meta name="keywords" content="musical scores, analysis, Digital and Cognitive Musicology Lab, École polytechnique fédérale de Lausanne"> -->
 


### PR DESCRIPTION
Just a half-liner to remove obsolete app names from the window title.