### PR TITLE
Improve visuals for relation with multiple notes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -101,7 +101,7 @@
             </feMerge>
         </filter>
         <filter id="selectFilter">
-            <feFlood result="flood" flood-color="green" />
+            <feFlood result="flood" flood-color="hsl(199, 98%, 55%)" />
             <feComposite in="flood" in2="SourceGraphic" operator="in" result="mask" />
             <feMorphology in="mask" operator="dilate" radius="2" result="thickened" />
             <feGaussianBlur in="thickened" stdDeviation="5" result="coloredBlur" />

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -164,7 +164,23 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
   )
 
   // Decorate with onclick and onmouseover handlers
-  group.onclick = () => toggle_selected(group)
+  group.onclick = () => {
+    toggle_selected(group)
+    primaries.forEach(item => {
+      if (item.classList.contains('relation-select-primary')) {
+        item.classList.remove('relation-select-primary')
+      } else {
+        item.classList.add('relation-select-primary')
+      }
+    })
+    secondaries.forEach(item => {
+      if (item.classList.contains('relation-select-secondary')) {
+        item.classList.remove('relation-select-secondary')
+      } else {
+        item.classList.add('relation-select-secondary')
+      }
+    })
+  }
   group.onmouseover = function () {
     primaries.forEach(item => item.classList.add('extrahover'))
     secondaries.forEach(item => item.classList.add('selecthover'))

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -115,12 +115,14 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
 
         // Use the best point for the jot position
         if (bestPoint) {
-          const jot = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
-          const radius = 80
+          const jot = document.createElementNS('http://www.w3.org/2000/svg', 'rect')
+          const size = 100 // Size is double the radius to maintain similar visual size
 
-          jot.setAttribute('cx', bestPoint.x)
-          jot.setAttribute('cy', bestPoint.y + radius / 2)
-          jot.setAttribute('r', radius)
+          // Position the rect - need to offset by half the size to center it on the bestPoint
+          jot.setAttribute('x', bestPoint.x - size / 4)
+          jot.setAttribute('y', bestPoint.y - size / 4)
+          jot.setAttribute('width', size / 2)
+          jot.setAttribute('height', size)
           jot.style.fill = getComputedStyle(group).getPropertyValue('--shade-alternate')
           jot.setAttribute('middle-note', middleNote.id)
 
@@ -130,10 +132,11 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
           line.setAttribute('x1', coords[0])
           line.setAttribute('y1', coords[1] - baseOffsetY)
           line.setAttribute('x2', bestPoint.x)
-          line.setAttribute('y2', bestPoint.y + radius)
+          line.setAttribute('y2', bestPoint.y + size) // Connect to the middle of the square
           line.setAttribute('stroke', 'currentColor')
           line.setAttribute('stroke-width', '30px')
           line.setAttribute('stroke-dasharray', '100 100')
+          line.classList.add('relation-jot-line')
 
           // Add connection line and jot to the group
           group.appendChild(line)

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -116,7 +116,7 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
         // Use the best point for the jot position
         if (bestPoint) {
           const jot = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
-          const radius = 105
+          const radius = 80
 
           jot.setAttribute('cx', bestPoint.x)
           jot.setAttribute('cy', bestPoint.y + radius / 2)

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -66,17 +66,81 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
   group.classList.add('relation')
   group.setAttribute('type', type)
 
-  // Draw slurs between consecutive notes
-  for (let i = 0; i < notes.length - 1; i++) {
-    const slur = draw_slur(notes[i], notes[i + 1])
+  // Draw a single slur from first note to last note
+  if (notes.length >= 2) {
+    const firstNote = notes[0]
+    const lastNote = notes[notes.length - 1]
+
+    // Create the single slur from first to last note
+    const slur = draw_slur(firstNote, lastNote)
 
     // Store note references in the slur element
-    slur.setAttribute('start-note', notes[i].id)
-    slur.setAttribute('end-note', notes[i + 1].id)
+    slur.setAttribute('start-note', firstNote.id)
+    slur.setAttribute('end-note', lastNote.id)
 
     // Apply the group's color to the slur
     slur.style.stroke = getComputedStyle(group).getPropertyValue('--shade-alternate')
+
     group.appendChild(slur)
+
+    // Add jots for any middle notes on the slur
+    if (notes.length > 2) {
+      // Get the length of the path for measurements
+      const pathLength = slur.getTotalLength()
+      const curveLength = pathLength / 2 // Top curve is roughly the first half
+
+      // Draw jots for middle notes
+      for (let i = 1; i < notes.length - 1; i++) {
+        const middleNote = notes[i]
+        const coords = note_coords(middleNote)
+
+        // Find the point on the top curve that best matches the x-coordinate of the middle note
+        let bestPoint = null
+        let minDistance = Infinity
+
+        // Sample points along the top curve to find the closest one to our x-coordinate
+        const numSamples = 100
+        for (let j = 0; j <= numSamples; j++) {
+          const samplePosition = j / numSamples * curveLength
+          const point = slur.getPointAtLength(samplePosition)
+
+          // Calculate distance to the target x-coordinate
+          const xDistance = Math.abs(point.x - coords[0])
+
+          if (xDistance < minDistance) {
+            minDistance = xDistance
+            bestPoint = point
+          }
+        }
+
+        // Use the best point for the jot position
+        if (bestPoint) {
+          const jot = document.createElementNS('http://www.w3.org/2000/svg', 'circle')
+          const radius = 105
+
+          jot.setAttribute('cx', bestPoint.x)
+          jot.setAttribute('cy', bestPoint.y + radius / 2)
+          jot.setAttribute('r', radius)
+          jot.style.fill = getComputedStyle(group).getPropertyValue('--shade-alternate')
+          jot.setAttribute('middle-note', middleNote.id)
+
+          // Create a dashed line connecting the middle note to the jot
+          const line = document.createElementNS('http://www.w3.org/2000/svg', 'line')
+          const baseOffsetY = 150
+          line.setAttribute('x1', coords[0])
+          line.setAttribute('y1', coords[1] - baseOffsetY)
+          line.setAttribute('x2', bestPoint.x)
+          line.setAttribute('y2', bestPoint.y + radius)
+          line.setAttribute('stroke', 'currentColor')
+          line.setAttribute('stroke-width', '30px')
+          line.setAttribute('stroke-dasharray', '100 100')
+
+          // Add connection line and jot to the group
+          group.appendChild(line)
+          group.appendChild(jot)
+        }
+      }
+    }
   }
 
   /**
@@ -157,7 +221,7 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
 
   // Where are our targets
   var coords = targets.map(target => {
-    const maxWidth = 80 // matches the maxWidth in draw_slur
+    const maxWidth = 100 // matches the maxWidth in draw_slur
 
     // Check if the target is a relation
     if (target.classList.contains('metarelation')) {

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -168,7 +168,6 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
 
   // Decorate with onclick and onmouseover handlers
   group.onclick = () => {
-    toggle_selected(group)
     primaries.forEach(item => {
       if (item.classList.contains('relation-select-primary')) {
         item.classList.remove('relation-select-primary')
@@ -183,6 +182,7 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
         item.classList.add('relation-select-secondary')
       }
     })
+    toggle_selected(group)
   }
   group.onmouseover = function () {
     primaries.forEach(item => item.classList.add('extrahover'))

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -118,6 +118,10 @@ export function toggle_selected(item, extra = null) {
 
     selected = selected.filter(x => x !== item)
     extraselected = extraselected.filter(x => x !== item)
+
+    // Remove relation-related highlight from notes if using unselect-all
+    document.querySelectorAll('.relation-select-primary').forEach(x => x.classList.remove('relation-select-primary'))
+    document.querySelectorAll('.relation-select-secondary').forEach(x => x.classList.remove('relation-select-secondary'))
   }
 
   /**

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1131,12 +1131,12 @@ export function draw_slur(startNote, endNote) {
   const maxExistingSlurs = Math.max(nStartSlur, nEndSlur)
   const additionalHeight = maxExistingSlurs * slurOffsetHeightUnit
   const width = Math.abs(adjustedEnd[0] - adjustedStart[0])
-  const maxSlurWidth = 120
+  const maxSlurWidth = 100
 
   let pathData
 
   // Adjust control points based on different start/end heights
-  if (width < 2000) {
+  if (width < 1000) {
     const height = width * 0.3 + additionalHeight
     const heightDiff = Math.abs(startOffsetY - endOffsetY)
     const midX = (adjustedStart[0] + adjustedEnd[0]) / 2

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1127,7 +1127,7 @@ export function draw_slur(startNote, endNote) {
   const adjustedEnd = [end[0], end[1] - endOffsetY]
 
   // Calculate base height and additional height for existing slurs
-  const slurOffsetHeightUnit = 80
+  const slurOffsetHeightUnit = 100
   const maxExistingSlurs = Math.max(nStartSlur, nEndSlur)
   const additionalHeight = maxExistingSlurs * slurOffsetHeightUnit
   const width = Math.abs(adjustedEnd[0] - adjustedStart[0])
@@ -1136,7 +1136,7 @@ export function draw_slur(startNote, endNote) {
   let pathData
 
   // Adjust control points based on different start/end heights
-  if (width < 1000) {
+  if (width < 3800) {
     const height = width * 0.3 + additionalHeight
     const heightDiff = Math.abs(startOffsetY - endOffsetY)
     const midX = (adjustedStart[0] + adjustedEnd[0]) / 2
@@ -1151,7 +1151,7 @@ export function draw_slur(startNote, endNote) {
       Q ${bottomControlPoint[0]},${bottomControlPoint[1]} ${adjustedStart[0]},${adjustedStart[1]}
       Z`
   } else {
-    const height = width * 0.05 < 2000 ? additionalHeight + width * 0.1 : additionalHeight + 2000
+    const height = additionalHeight + Math.min(width * 0.05, 2000)
     const minY = Math.min(startOffsetY, endOffsetY)
 
     // Calculate control points at 20% and 80% of the width

--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -368,7 +368,8 @@ body:not(.mousedown) .metarelation:hover rect {
   visibility: hidden;
 }
 .relation:hover line,
-.relation.selectedrelation line {
+.relation.selectedrelation line,
+.relation.extraselectedrelation line {
   visibility: visible;
 }
 body:not(.mousedown) .relation:hover path {
@@ -387,7 +388,7 @@ body:not(.mousedown) .shift-pressed .metarelation:hover rect {
        stroke-width: 15px;
        stroke-opacity: 0.8;
 }
-.selectedrelation line,
+.selectedrelation line:not(.relation-jot-line),
 .selectedrelation rect,
 .selectedrelation path {
     fill-opacity : 0.7;
@@ -396,6 +397,11 @@ body:not(.mousedown) .shift-pressed .metarelation:hover rect {
     stroke-dasharray: 100 100;
     stroke-width: 15px;
     filter : url("#selectFilter");
+}
+.selectedrelation .relation-jot-line {
+  stroke: blue !important;
+  stroke-width: 30px;
+  stroke-opacity: 0.8;
 }
 body:not(.mousedown) .extraselectedrelation:hover path,
 body:not(.mousedown) .extraselectedrelation:hover line,
@@ -407,7 +413,7 @@ body:not(.mousedown) .extraselectedrelation:hover rect{
     stroke-opacity: 0.8;
 }
 .extraselectedrelation path,
-.extraselectedrelation line,
+.extraselectedrelation line:not(.relation-jot-line),
 .extraselectedrelation rect {
     fill-opacity : 0.7;
     stroke-opacity : 0.8;
@@ -416,6 +422,11 @@ body:not(.mousedown) .extraselectedrelation:hover rect{
     stroke-width: 15px;
     transform : translate3d(0,0,0);
     filter : url("#extraFilter");
+}
+.extraselectedrelation .relation-jot-line {
+  stroke: red !important;
+  stroke-width: 30px;
+  stroke-opacity: 0.8;
 }
 .relationhover {
       transform: translate3d(0,0,0);

--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -361,7 +361,13 @@ body:not(.mousedown) .metarelation:hover rect {
     transform : translate3d(0,0,0);
     filter : url("#selectFilter");
 }
-
+.relation line {
+  visibility: hidden;
+}
+.relation:hover line,
+.relation.selectedrelation line {
+  visibility: visible;
+}
 body:not(.mousedown) .relation:hover path {
       transform: translate3d(0,0,0);
        filter: url("#glowFilter");

--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -314,14 +314,17 @@ body:not(.mousedown) .note:hover {
 .selectednote {
   color: green;
 }
-.extrahover {
-      transform: translate3d(0,0,0);
-       filter: url("#extraFilter");
-       color: red;
+.extrahover,
+.relation-select-primary {
+  transform: translate3d(0,0,0);
+  filter: url("#extraFilter");
+  color: red;
 }
-.selecthover {
-      transform: translate3d(0,0,0);
-       filter: url("#selectFilter");
+.selecthover,
+.relation-select-secondary {
+  transform: translate3d(0,0,0);
+  filter: url("#selectFilter");
+  color: hsl(199, 98%, 55%);
 }
 .secondarynote {
   opacity: calc(1.0 / var(--how-secondary));


### PR DESCRIPTION
> Use single slurs for relations, regardless of number of member notes.
> Add a small jot on the slur for every member note.
> On hover or select, draw dotted lines between each jot/asterisk and the respective note-head.
> On hover or select, highlight the member note-heads with a bright semi-transparent color.

Example:
<img width="230" alt="image" src="https://github.com/user-attachments/assets/c8bfd6c3-cc1f-423c-a220-c9e5e3fab8eb" />
