### PR TITLE
Downward slur v2

### DIFF
--- a/src/components.html
+++ b/src/components.html
@@ -614,7 +614,7 @@
     <label class="score-setting relation-width | btn btn--small btn--plain" for="relation-width">
         Relation width
         <div class="relation-width__progress-range | progress-range" style="--progress: .35;">
-            <input class="progress-range__input relation-width__range" type="range" min="20" value="85" max="200" name="relation-width" id="relation-width">
+            <input class="progress-range__input relation-width__range" type="range" min="0.1" value="0.5" max="1" name="relation-width" id="relation-width">
             <span class="progress-range__bar"></span>
             <span class="progress-range__thumb"></span>
         </div>

--- a/src/index.html
+++ b/src/index.html
@@ -594,7 +594,7 @@
 
             <!-- Relation width -->
             <label class="score-setting relation-width | hidden-when-score-settings-not-visible | btn btn--small btn--plain" for="relation-width">
-                Relation width
+                Slur curvature
 
                 <input class="progress-range__input relation-width__range" type="range" min="0.1" value="0.5" max="1.0" step="0.1" name="relation-width" id="relation-width">
 

--- a/src/index.html
+++ b/src/index.html
@@ -596,7 +596,7 @@
             <label class="score-setting relation-width | hidden-when-score-settings-not-visible | btn btn--small btn--plain" for="relation-width">
                 Relation width
 
-                <input class="progress-range__input relation-width__range" type="range" min="20" value="200" max="200" step="2" name="relation-width" id="relation-width">
+                <input class="progress-range__input relation-width__range" type="range" min="0.1" value="0.5" max="1.0" step="0.1" name="relation-width" id="relation-width">
 
                 <div class="relation-width__progress-range | progress-range" id="relation-width-progress-ctn">
                     <span class="progress-range__bar"></span>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -455,6 +455,7 @@ function load_finish(loader_modal) {
   document.getElementById('layers').innerHTML = ''
 
   draw_contexts.hullPadding = 200
+  draw_contexts.curvatureFactor = 0.5
 
   // Segment existing layers
   var layers = Array.from(mei.getElementsByTagName('body')[0].getElementsByTagName('mdiv'))

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -84,6 +84,7 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
     slur.style.stroke = getComputedStyle(group).getPropertyValue('--shade-alternate')
 
     group.appendChild(slur)
+    group.setAttribute('is-downward', isDownward)
 
     // Add jots for any middle notes on the slur
     if (notes.length > 2) {
@@ -240,16 +241,21 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
     return []
   }
 
+  const isDownward = targets.every(target => target.getAttribute('is-downward') === 'true')
+
   // Where are our targets
   var coords = targets.map(target => {
     const maxWidth = 100 // matches the maxWidth in draw_slur
 
-    // Check if the target is a relation
+    // Check if the target is a metarelation
     if (target.classList.contains('metarelation')) {
       // Get the bounding rect of the relation
       const bbox = target.getBBox()
       // Return the middle point of the upper edge
-      return {
+      return isDownward ? {
+        point: [bbox.x + bbox.width / 2, bbox.y + bbox.height],
+        width: maxWidth
+      } : {
         point: [bbox.x + bbox.width / 2, bbox.y],
         width: maxWidth
       }
@@ -261,14 +267,19 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
       // Find the highest point and corresponding width of all slurs in this relation
       const slurInfo = slurs.map(slur => {
         const bbox = slur.getBBox()
-        return {
-          point: [bbox.x + bbox.width / 2, bbox.y],
-          width: maxWidth
-        }
+        return isDownward
+          ? {
+            point: [bbox.x + bbox.width / 2, bbox.y + bbox.height],
+            width: maxWidth,
+          }
+          : {
+            point: [bbox.x + bbox.width / 2, bbox.y],
+            width: maxWidth,
+          }
       })
-
-      // Return the highest point and its corresponding width
-      return slurInfo.reduce((highest, current) =>
+      return isDownward ? slurInfo.reduce((lowest, current) =>
+        current.point[1] > lowest.point[1] ? current : lowest
+      ) : slurInfo.reduce((highest, current) =>
         current.point[1] < highest.point[1] ? current : highest
       )
     }
@@ -276,7 +287,7 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
 
   // What's midpoint above them?
   var x = average(coords.map((e) => e.point[0]))
-  let yOffset = -400
+  let yOffset = isDownward ? 400 : -400
   var y = Math.min(...coords.map(c => c.point[1])) + yOffset
 
   // Store original coords for line connections
@@ -291,6 +302,7 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
   g_elem.setAttribute('type', type)
   g_elem.setAttribute('start-relation', targets[0].id)
   g_elem.setAttribute('end-relation', targets[1].id)
+  g_elem.setAttribute('is-downward', isDownward)
   // Draw the metarelation as a circle connected with lines to each of its
   // targets
   const rectHeight = 250
@@ -371,7 +383,7 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
     if (!connection_circle) {
       // Draw a connection circle at the connection point if not already present
       const radius = info.width / 2
-      const adjustedPoint = [info.point[0], info.point[1] + radius / 2]
+      const adjustedPoint = [info.point[0], isDownward ? info.point[1] - radius / 2 : info.point[1] + radius / 2]
       connection_circle = circle(adjustedPoint, radius)
       connection_circle.style.fill = 'white'
       connection_circle.style.stroke = '#000'

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -26,6 +26,7 @@ import {
   relation_secondaries,
   relation_type,
   draw_slur,
+  isSlurDownward
 } from './utils'
 
 // Given a draw context and a graph node representing a relation, draw the
@@ -66,17 +67,12 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
   group.classList.add('relation')
   group.setAttribute('type', type)
 
-  let system_bbox = svg_elem.querySelector('svg.definition-scale').getBBox()
-  let system_mid = system_bbox.y + system_bbox.height / 2
-
   // Draw a single slur from first note to last note
   if (notes.length >= 2) {
     const firstNote = notes[0]
     const lastNote = notes[notes.length - 1]
     // Downward slur if both notes are below the system's midpoint
-    const isDownward = system_mid < note_coords(firstNote)[1] && system_mid < note_coords(lastNote)[1]
-    console.log('isDownward', isDownward)
-
+    const isDownward = isSlurDownward(svg_elem, firstNote, lastNote)
     // Create the single slur from first to last note
     const slur = draw_slur(firstNote, lastNote, isDownward)
 

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -66,13 +66,19 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
   group.classList.add('relation')
   group.setAttribute('type', type)
 
+  let system_bbox = svg_elem.querySelector('svg.definition-scale').getBBox()
+  let system_mid = system_bbox.y + system_bbox.height / 2
+
   // Draw a single slur from first note to last note
   if (notes.length >= 2) {
     const firstNote = notes[0]
     const lastNote = notes[notes.length - 1]
+    // Downward slur if both notes are below the system's midpoint
+    const isDownward = system_mid < note_coords(firstNote)[1] && system_mid < note_coords(lastNote)[1]
+    console.log('isDownward', isDownward)
 
     // Create the single slur from first to last note
-    const slur = draw_slur(firstNote, lastNote)
+    const slur = draw_slur(firstNote, lastNote, isDownward)
 
     // Store note references in the slur element
     slur.setAttribute('start-note', firstNote.id)
@@ -120,7 +126,7 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
 
           // Position the rect - need to offset by half the size to center it on the bestPoint
           jot.setAttribute('x', bestPoint.x - size / 4)
-          jot.setAttribute('y', bestPoint.y - size / 4)
+          jot.setAttribute('y', isDownward ? bestPoint.y - size * 0.75 : bestPoint.y - size / 4)
           jot.setAttribute('width', size / 2)
           jot.setAttribute('height', size)
           jot.style.fill = getComputedStyle(group).getPropertyValue('--shade-alternate')
@@ -130,9 +136,9 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
           const line = document.createElementNS('http://www.w3.org/2000/svg', 'line')
           const baseOffsetY = 150
           line.setAttribute('x1', coords[0])
-          line.setAttribute('y1', coords[1] - baseOffsetY)
+          line.setAttribute('y1', isDownward ? coords[1] + baseOffsetY : coords[1] - baseOffsetY)
           line.setAttribute('x2', bestPoint.x)
-          line.setAttribute('y2', bestPoint.y + size) // Connect to the middle of the square
+          line.setAttribute('y2', isDownward ? bestPoint.y - size : bestPoint.y + size) // Connect to the middle of the square
           line.setAttribute('stroke', 'currentColor')
           line.setAttribute('stroke-width', '30px')
           line.setAttribute('stroke-dasharray', '100 100')

--- a/src/js/new/modules/UI/RelationWidth/index.js
+++ b/src/js/new/modules/UI/RelationWidth/index.js
@@ -1,4 +1,4 @@
-import { handle_hull_controller } from '../../../../ui'
+import { handle_curvature_controller } from '../../../../ui'
 import Progress from './progress'
 
 class RelationWidth {
@@ -7,6 +7,7 @@ class RelationWidth {
 
     const { min, max, value } = this.input
     this.progressBar = new Progress('relation-width', { min, max, value })
+    console.log('initializing relation width controller with value ', this.input.value)
 
     this.throttling = false
   }
@@ -19,9 +20,9 @@ class RelationWidth {
     this.throttling = true
 
     requestAnimationFrame(() => {
-      const value = parseInt(target.value)
+      const value = target.value
       this.progressBar.update(value)
-      handle_hull_controller(value)
+      handle_curvature_controller(value)
       this.throttling = false
     })
   }

--- a/src/js/new/modules/UI/RelationWidth/progress.js
+++ b/src/js/new/modules/UI/RelationWidth/progress.js
@@ -4,8 +4,11 @@ export default class Progress {
   constructor(idPrefix = '', options) {
     this.ctn = document.getElementById(`${idPrefix}-progress-ctn`)
 
-    this.setMinMax(options)
-    this.update(options.value)
+    if (options) {
+      console.log('Progress options', options)
+      this.setMinMax(options)
+      this.update(options.value)
+    }
   }
 
   setMinMax({ min, max }) {

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -611,11 +611,6 @@ export function adjustSvgDimensions(draw_context) {
   const newSvgWidth = newMaxX - newMinX
   const newSvgHeight = newMaxY - newMinY
 
-  // Only update viewBox if needed
-  if (newMinX !== x || newMinY !== y || newSvgWidth !== w || newSvgHeight !== h) {
-    definitionScale.setAttribute('viewBox', `${newMinX} ${newMinY} ${newSvgWidth} ${newSvgHeight}`)
-  }
-
   // Convert SVG units to pixels using the scale factors
   const newPixelWidth = Math.ceil(newSvgWidth * scaleX)
   const newPixelHeight = Math.ceil(newSvgHeight * scaleY)

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -34,19 +34,11 @@ import {
 import { do_reduce_pre } from './reductions'
 import { draw_hierarchy_graph } from './visualizations'
 
-import { do_copy, do_paste }  from './copy_paste'
+import { do_copy, do_paste } from './copy_paste'
 
-import {
-  flip_to_bg,
-  get_class_from_classlist,
-  select_samenote,
-  unmark_secondaries
-} from './utils'
+import { flip_to_bg, get_class_from_classlist, select_samenote, unmark_secondaries } from './utils'
 
-import {
-  place_note,
-  update_placing_note
-} from './coordinates'
+import { place_note, update_placing_note } from './coordinates'
 
 import { delete_relations } from './delete'
 import { do_redo, do_undo } from './undo_redo'
@@ -112,16 +104,22 @@ export function toggle_selected(item, extra = null) {
 
   if (isAlreadySelected) {
     item.classList.remove(
-      'selectednote', 'extraselectednote',
-      'selectedrelation', 'extraselectedrelation'
+      'selectednote',
+      'extraselectednote',
+      'selectedrelation',
+      'extraselectedrelation'
     )
 
     selected = selected.filter(x => x !== item)
     extraselected = extraselected.filter(x => x !== item)
 
     // Remove relation-related highlight from notes if using unselect-all
-    document.querySelectorAll('.relation-select-primary').forEach(x => x.classList.remove('relation-select-primary'))
-    document.querySelectorAll('.relation-select-secondary').forEach(x => x.classList.remove('relation-select-secondary'))
+    document
+      .querySelectorAll('.relation-select-primary')
+      .forEach(x => x.classList.remove('relation-select-primary'))
+    document
+      .querySelectorAll('.relation-select-secondary')
+      .forEach(x => x.classList.remove('relation-select-secondary'))
   }
 
   /**
@@ -145,7 +143,6 @@ export function toggle_selected(item, extra = null) {
         item.classList.add('selectednote')
         selected.push(item)
       }
-
     } else {
       const noteIdIndex = selectedNotesIds.findIndex(id => item.id == id)
       selectedNotesIds.splice(noteIdIndex, 1)
@@ -183,17 +180,21 @@ export function toggle_selected(item, extra = null) {
     extraselected: extraselected,
   }
 
-  document.dispatchEvent(new CustomEvent('scoreselection', {
-    detail: {
-      selection,
-      lastSelected: last_selected,
-    },
-  }))
+  document.dispatchEvent(
+    new CustomEvent('scoreselection', {
+      detail: {
+        selection,
+        lastSelected: last_selected,
+      },
+    })
+  )
 }
 
 export function select_visibles(draw_context) {
   // Find all non-filtered relationships in the draw context.
-  var visibles = Array.from(draw_context.svg_elem.getElementsByClassName('relation')).filter(n => !n.classList.contains('relation--filtered'))
+  var visibles = Array.from(draw_context.svg_elem.getElementsByClassName('relation')).filter(
+    n => !n.classList.contains('relation--filtered')
+  )
 
   // Clear out any selections in other contexts.
   if (visibles.length > 0) {
@@ -204,20 +205,20 @@ export function select_visibles(draw_context) {
       var cdsel = selected.concat(extraselected)[0].closest('div')
       // Select only things of the same type for now - editing
       // relations to add things means deleting and re-adding
-      if (csel != 'relation')
-        do_deselect()
-      if (cd != cdsel)
-        do_deselect()
+      if (csel != 'relation') do_deselect()
+      if (cd != cdsel) do_deselect()
     }
 
     // Add all visible yet still unselected relations to selection list.
-    visibles.forEach(n => { if (!n.classList.contains('selectedrelation')) toggle_selected(n) })
+    visibles.forEach(n => {
+      if (!n.classList.contains('selectedrelation')) toggle_selected(n)
+    })
   }
 }
 
 /* Keypress/mouse handler functions */
 
-window.onmousemove = (e) => {
+window.onmousemove = e => {
   mouseX = e.clientX
   mouseY = e.clientY
 
@@ -228,8 +229,7 @@ window.onmousemove = (e) => {
 
 export function handle_keydown(ev) {
   // Global `.shift-pressed` class for pretty (meta-)relation styling on hover.
-  if (ev.key === 'Shift')
-    $('#layers').addClass('shift-pressed')
+  if (ev.key === 'Shift') $('#layers').addClass('shift-pressed')
 
   // Add space drag functionality (commented out due to performance issues)
   if (ev.key === ' ' || ev.key === 'Space') {
@@ -250,8 +250,7 @@ export function handle_keydown(ev) {
 
 export function handle_keyup(ev) {
   // Global `.shift-pressed` class for pretty (meta-)relation styling on hover.
-  if (ev.key === 'Shift')
-    $('#layers').removeClass('shift-pressed')
+  if (ev.key === 'Shift') $('#layers').removeClass('shift-pressed')
 
   // Remove space drag functionality (commented out due to performance issues)
   // if (ev.key === ' ' || ev.key === 'Space') {
@@ -276,62 +275,86 @@ export function handle_click(ev) {
 export function handle_keypress(ev) {
   var e
 
-  if (isFieldFocused()) { return }
+  if (isFieldFocused()) {
+    return
+  }
 
   if (ev.key == 'Enter') {
     // do_edges()
-  } else if (ev.key == action_conf.move_relation_to_front) { // Scroll through relations
+  } else if (ev.key == action_conf.move_relation_to_front) {
+    // Scroll through relations
     var elem = document.elementFromPoint(mouseX, mouseY)
-    if (elem.tagName == 'circle')
-      elem = elem.closest('g')
+    if (elem.tagName == 'circle') elem = elem.closest('g')
     flip_to_bg(elem)
     if (elem.onmouseout) elem.onmouseout()
     var elem = document.elementFromPoint(mouseX, mouseY)
-    if (elem.tagName == 'circle')
-      elem = elem.closest('g')
-    document.dispatchEvent(new CustomEvent('fliprelation', { detail: {
-      target: elem
-    } }))
-  } else if (ev.key == action_conf.undo) { // UNDO
+    if (elem.tagName == 'circle') elem = elem.closest('g')
+    document.dispatchEvent(
+      new CustomEvent('fliprelation', {
+        detail: {
+          target: elem,
+        },
+      })
+    )
+  } else if (ev.key == action_conf.undo) {
+    // UNDO
     do_undo()
-  } else if (ev.key == action_conf.redo) { // UNDO
+  } else if (ev.key == action_conf.redo) {
+    // UNDO
     do_redo()
-  } else if (ev.key == action_conf.copy) { // COPY
+  } else if (ev.key == action_conf.copy) {
+    // COPY
     do_copy()
-  } else if (ev.key == action_conf.paste) { // PASTE
+  } else if (ev.key == action_conf.paste) {
+    // PASTE
     do_paste()
-  } else if (ev.key == action_conf.reduce_relations) { // Reduce relations
+  } else if (ev.key == action_conf.reduce_relations) {
+    // Reduce relations
     do_reduce_pre(current_draw_context)
-  } else if (ev.key == action_conf.select_same_notes) { // Select same notes in the measure
+  } else if (ev.key == action_conf.select_same_notes) {
+    // Select same notes in the measure
     select_samenote()
     do_relation('repeat')
-  } else if (ev.key == action_conf.naturalize_note) { // Naturalize note.
+  } else if (ev.key == action_conf.naturalize_note) {
+    // Naturalize note.
     accidentals.naturalize()
-  } else if (ev.key == navigation_conf.jump_to_next_bookmark) { // Jump to previous bookmark in current context.
+  } else if (ev.key == navigation_conf.jump_to_next_bookmark) {
+    // Jump to previous bookmark in current context.
     bookmarks.goTo(-1)
-  } else if (ev.key == navigation_conf.jump_to_previous_bookmark) { // Jump to next bookmark in current context.
+  } else if (ev.key == navigation_conf.jump_to_previous_bookmark) {
+    // Jump to next bookmark in current context.
     bookmarks.goTo(1)
-  } else if (ev.key == navigation_conf.jump_to_context_below) { // Jump to next context.
+  } else if (ev.key == navigation_conf.jump_to_context_below) {
+    // Jump to next context.
     layersMenu.moveBy(1)
-  } else if (ev.key == navigation_conf.jump_to_context_above) { // Jump to previous context.
+  } else if (ev.key == navigation_conf.jump_to_context_above) {
+    // Jump to previous context.
     layersMenu.moveBy(-1)
-  } else if (ev.key == action_conf.deselect_all) { // Deselect all.
+  } else if (ev.key == action_conf.deselect_all) {
+    // Deselect all.
     do_deselect()
-  } else if (ev.key == action_conf.delete_all) { // Delete relations.
+  } else if (ev.key == action_conf.delete_all) {
+    // Delete relations.
     delete_relations()
-  } else if (ev.key == action_conf.add_bookmark) { // Add bookmark.
+  } else if (ev.key == action_conf.add_bookmark) {
+    // Add bookmark.
     bookmarks.toggle()
-  } else if (ev.key == custom_conf.relation) { // Custom relations.
+  } else if (ev.key == custom_conf.relation) {
+    // Custom relations.
     ev.preventDefault()
     // $('#custom_type').select2('open')
-  } else if (ev.key == custom_conf.meta_relation) { // Custom meta-relations.
+  } else if (ev.key == custom_conf.meta_relation) {
+    // Custom meta-relations.
     ev.preventDefault()
     // $('#meta_custom_type').select2('open')
-  } else if (e = Object.entries(type_conf).find((c) => c[1].key == ev.key)) { // Add a relation
+  } else if ((e = Object.entries(type_conf).find(c => c[1].key == ev.key))) {
+    // Add a relation
     do_relation(e[0])
-  } else if (e = Object.entries(meta_conf).find((c) => c[1].key == ev.key)) { // Add a metarelation
+  } else if ((e = Object.entries(meta_conf).find(c => c[1].key == ev.key))) {
+    // Add a metarelation
     do_metarelation(e[0])
-  } else if (e = Object.entries(combo_conf).find((c) => c[1].key == ev.key)) { // Add a comborelation
+  } else if ((e = Object.entries(combo_conf).find(c => c[1].key == ev.key))) {
+    // Add a comborelation
     do_comborelation(e[0])
   } else {
     console.log(ev)
@@ -351,13 +374,16 @@ export function toggle_equalize() {
 function set_non_note_visibility(hidden) {
   console.debug('Using globals: document for element selection')
 
-  Array.from(document.getElementsByClassName('beam')).forEach(x => Array.from(x.children)
-    .filter(x => x.tagName == 'polygon')
-    .forEach(x => x.classList.toggle('hidden', hidden)))
+  Array.from(document.getElementsByClassName('beam')).forEach(x =>
+    Array.from(x.children)
+      .filter(x => x.tagName == 'polygon')
+      .forEach(x => x.classList.toggle('hidden', hidden))
+  )
 
   hide_classes.forEach(cl =>
-    Array.from(document.getElementsByClassName(cl))
-      .forEach(x => x.classList.toggle('hidden', hidden))
+    Array.from(document.getElementsByClassName(cl)).forEach(x =>
+      x.classList.toggle('hidden', hidden)
+    )
   )
 }
 
@@ -401,7 +427,7 @@ export function getReducedMidi(draw_context = null) {
   return midi
 }
 
-export function handle_hull_controller(value) {
+export function handle_curvature_controller(value) {
   var mei_graph = getMeiGraph()
   var draw_contexts = getDrawContexts()
   do_deselect()
@@ -411,11 +437,10 @@ export function handle_hull_controller(value) {
   var relations_nodes = nodes_array.filter(x => x.getAttribute('type') == 'relation')
   var metarelations_nodes = nodes_array.filter(x => x.getAttribute('type') == 'metarelation')
   draw_contexts.forEach(draw_context => {
-    relations_nodes.forEach(
-      g_elem => unmark_secondaries(draw_context, mei_graph, g_elem)
-    )
+    relations_nodes.forEach(g_elem => unmark_secondaries(draw_context, mei_graph, g_elem))
   })
-  draw_contexts.hullPadding = value
+  draw_contexts.curvatureFactor = value
+  console.log('Updating relation width controller with value', value)
   draw_contexts.forEach(draw_graph)
 
   // update hierarchy trees
@@ -433,7 +458,7 @@ export function drag_selector_installer(svg_elem) {
     area: $('#layers')[0],
     draggability: false,
     overflowTolerance: { x: 1, y: 1 },
-    autoScrollSpeed: 0.0001
+    autoScrollSpeed: 0.0001,
   })
 
   drag_selector.subscribe('dragstart', ({ items, event, isDragging }) => {
@@ -442,14 +467,14 @@ export function drag_selector_installer(svg_elem) {
 
   drag_selector.subscribe('dragmove', ({ items, event, isDragging }) => {
     // Do not drag-select if a note is being added
-    if (
-      placing_note == ''
-    ) {
+    if (placing_note == '') {
       if ($('.ds-selector').height() > 10 || $('.ds-selector').width() > 10) {
         // Icon credit: pixel-perfect (flaticon.com).
-        document.getElementById('layers').style.cursor = 'url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjJwdCIgaGVpZ2h0PSIyMnB0IiB2aWV3Qm94PSIwIDAgMjIgMjIiIHZlcnNpb249IjEuMSI+CjxnIGlkPSJzdXJmYWNlMSI+CjxwYXRoIHN0eWxlPSIgc3Ryb2tlOm5vbmU7ZmlsbC1ydWxlOm5vbnplcm87ZmlsbDpyZ2IoMCUsMCUsMCUpO2ZpbGwtb3BhY2l0eToxOyIgZD0iTSA0LjQ0OTIxOSAxNC44MDA3ODEgQyA0LjI2OTUzMSAxNC42MjEwOTQgMy45ODA0NjkgMTQuNjIxMDk0IDMuODAwNzgxIDE0LjgwMDc4MSBDIDMuNjIxMDk0IDE0Ljk4MDQ2OSAzLjYyMTA5NCAxNS4yNjk1MzEgMy44MDA3ODEgMTUuNDQ5MjE5IEMgNS43Njk1MzEgMTcuNDE3OTY5IDUuNzY5NTMxIDE5LjI1IDMuODAwNzgxIDIxLjIxODc1IEMgMy42MjEwOTQgMjEuMzk4NDM4IDMuNjIxMDk0IDIxLjY4NzUgMy44MDA3ODEgMjEuODY3MTg4IEMgMy44OTA2MjUgMjEuOTU3MDMxIDQuMDA3ODEyIDIyIDQuMTI1IDIyIEMgNC4yNDIxODggMjIgNC4zNTkzNzUgMjEuOTU3MDMxIDQuNDQ5MjE5IDIxLjg2NzE4OCBDIDYuNzU3ODEyIDE5LjU1NDY4OCA2Ljc1NzgxMiAxNy4xMTMyODEgNC40NDkyMTkgMTQuODAwNzgxIFogTSA0LjQ0OTIxOSAxNC44MDA3ODEgIi8+CjxwYXRoIHN0eWxlPSIgc3Ryb2tlOm5vbmU7ZmlsbC1ydWxlOm5vbnplcm87ZmlsbDpyZ2IoMCUsMCUsMCUpO2ZpbGwtb3BhY2l0eToxOyIgZD0iTSA0LjEyNSAxMS45MTc5NjkgQyAzLjExMzI4MSAxMS45MTc5NjkgMi4yOTI5NjkgMTIuNzM4MjgxIDIuMjkyOTY5IDEzLjc1IEMgMi4yOTI5NjkgMTQuNzYxNzE5IDMuMTEzMjgxIDE1LjU4MjAzMSA0LjEyNSAxNS41ODIwMzEgQyA1LjEzNjcxOSAxNS41ODIwMzEgNS45NTcwMzEgMTQuNzYxNzE5IDUuOTU3MDMxIDEzLjc1IEMgNS45NTcwMzEgMTIuNzM4MjgxIDUuMTM2NzE5IDExLjkxNzk2OSA0LjEyNSAxMS45MTc5NjkgWiBNIDQuMTI1IDE0LjY2Nzk2OSBDIDMuNjIxMDk0IDE0LjY2Nzk2OSAzLjIwNzAzMSAxNC4yNTM5MDYgMy4yMDcwMzEgMTMuNzUgQyAzLjIwNzAzMSAxMy4yNDYwOTQgMy42MjEwOTQgMTIuODMyMDMxIDQuMTI1IDEyLjgzMjAzMSBDIDQuNjI4OTA2IDEyLjgzMjAzMSA1LjA0Mjk2OSAxMy4yNDYwOTQgNS4wNDI5NjkgMTMuNzUgQyA1LjA0Mjk2OSAxNC4yNTM5MDYgNC42Mjg5MDYgMTQuNjY3OTY5IDQuMTI1IDE0LjY2Nzk2OSBaIE0gNC4xMjUgMTQuNjY3OTY5ICIvPgo8cGF0aCBzdHlsZT0iIHN0cm9rZTpub25lO2ZpbGwtcnVsZTpub256ZXJvO2ZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiIGQ9Ik0gMjEuNzY1NjI1IDEzLjgwODU5NCBMIDEzLjUxNTYyNSA5LjIyMjY1NiBDIDEzLjM0Mzc1IDkuMTI4OTA2IDEzLjEzNjcxOSA5LjE1MjM0NCAxMi45ODgyODEgOS4yODEyNSBDIDEyLjg0Mzc1IDkuNDEwMTU2IDEyLjc5Mjk2OSA5LjYxMzI4MSAxMi44NjcxODggOS43OTY4NzUgTCAxNi41MzEyNSAxOC45NjA5MzggQyAxNi42MDE1NjIgMTkuMTMyODEyIDE2Ljc2OTUzMSAxOS4yNSAxNi45NTMxMjUgMTkuMjUgQyAxNi45NTMxMjUgMTkuMjUgMTYuOTU3MDMxIDE5LjI1IDE2Ljk1NzAzMSAxOS4yNSBDIDE3LjE0MDYyNSAxOS4yNSAxNy4zMDg1OTQgMTkuMTQwNjI1IDE3LjM3ODkwNiAxOC45NzI2NTYgTCAxOC42ODM1OTQgMTUuOTMzNTk0IEwgMjEuNzIyNjU2IDE0LjYyODkwNiBDIDIxLjg4MjgxMiAxNC41NjI1IDIxLjk4ODI4MSAxNC40MDYyNSAyMiAxNC4yMzA0NjkgQyAyMi4wMDc4MTIgMTQuMDU4NTk0IDIxLjkxNzk2OSAxMy44OTQ1MzEgMjEuNzY1NjI1IDEzLjgwODU5NCBaIE0gMjEuNzY1NjI1IDEzLjgwODU5NCAiLz4KPHBhdGggc3R5bGU9IiBzdHJva2U6bm9uZTtmaWxsLXJ1bGU6bm9uemVybztmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7IiBkPSJNIDUuNjY0MDYyIDEyLjc2NTYyNSBDIDUuNTc4MTI1IDEyLjYyODkwNiA1LjQ3MjY1NiAxMi41MDc4MTIgNS4zNTU0NjkgMTIuNDAyMzQ0IEMgNS4zMzk4NDQgMTIuMzg2NzE5IDUuMzI0MjE5IDEyLjM3NSA1LjMwODU5NCAxMi4zNjMyODEgQyA1LjIxMDkzOCAxMi4yNzczNDQgNS4xMDU0NjkgMTIuMjA3MDMxIDQuOTkyMTg4IDEyLjE0NDUzMSBDIDQuOTYwOTM4IDEyLjEyODkwNiA0LjkyOTY4OCAxMi4xMDkzNzUgNC44OTg0MzggMTIuMDkzNzUgQyA0Ljc3MzQzOCAxMi4wMzUxNTYgNC42NDQ1MzEgMTEuOTg4MjgxIDQuNTA3ODEyIDExLjk1NzAzMSBDIDQuNDY4NzUgMTEuOTQ5MjE5IDQuNDI1NzgxIDExLjk0OTIxOSA0LjM4MjgxMiAxMS45NDE0MDYgQyA0LjI2OTUzMSAxMS45MjU3ODEgNC4xNTIzNDQgMTEuOTE3OTY5IDQuMDM5MDYyIDExLjkyNTc4MSBDIDMuNjMyODEyIDExLjk0NTMxMiAzLjI2NTYyNSAxMi4wOTc2NTYgMi45Njg3NSAxMi4zMzU5MzggQyAzLjE5MTQwNiAxMi40OTYwOTQgMy40MTQwNjIgMTIuNjQ4NDM4IDMuNjU2MjUgMTIuNzkyOTY5IEMgMy43NSAxMi44NDc2NTYgMy44NTkzNzUgMTIuODY3MTg4IDMuOTY4NzUgMTIuODUxNTYyIEMgNC4zNDc2NTYgMTIuNzg1MTU2IDQuNzUzOTA2IDEyLjk3NjU2MiA0LjkzNzUgMTMuMzM1OTM4IEMgNC45ODgyODEgMTMuNDMzNTk0IDUuMDcwMzEyIDEzLjUxMTcxOSA1LjE2Nzk2OSAxMy41NTA3ODEgQyA1LjQyMTg3NSAxMy42NTYyNSA1LjY4NzUgMTMuNzM4MjgxIDUuOTQ5MjE5IDEzLjgyODEyNSBDIDUuOTQ5MjE5IDEzLjgwMDc4MSA1Ljk1NzAzMSAxMy43NzczNDQgNS45NTcwMzEgMTMuNzUgQyA1Ljk1NzAzMSAxMy4zODY3MTkgNS44NDc2NTYgMTMuMDUwNzgxIDUuNjY0MDYyIDEyLjc2NTYyNSBaIE0gNS42NjQwNjIgMTIuNzY1NjI1ICIvPgo8cGF0aCBzdHlsZT0iIHN0cm9rZTpub25lO2ZpbGwtcnVsZTpub256ZXJvO2ZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiIGQ9Ik0gMTMuMzgyODEyIDEzLjU1ODU5NCBDIDExLjE5MTQwNiAxMy44OTg0MzggOC44NTkzNzUgMTMuNzUgNi44MDQ2ODggMTMuMTUyMzQ0IEMgNi44NDc2NTYgMTMuMzQzNzUgNi44NzUgMTMuNTQyOTY5IDYuODc1IDEzLjc1IEMgNi44NzUgMTMuODcxMDk0IDYuODU1NDY5IDEzLjk4ODI4MSA2LjgzOTg0NCAxNC4xMDkzNzUgQyA4LjE1NjI1IDE0LjQ2ODc1IDkuNTY2NDA2IDE0LjY2Nzk2OSAxMSAxNC42Njc5NjkgQyAxMS45MjU3ODEgMTQuNjY3OTY5IDEyLjgzOTg0NCAxNC41ODIwMzEgMTMuNzM0Mzc1IDE0LjQyOTY4OCBaIE0gMTMuMzgyODEyIDEzLjU1ODU5NCAiLz4KPHBhdGggc3R5bGU9IiBzdHJva2U6bm9uZTtmaWxsLXJ1bGU6bm9uemVybztmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7IiBkPSJNIDExIDAgQyA0LjkzMzU5NCAwIDAgMy4yODkwNjIgMCA3LjMzMjAzMSBDIDAgOC45NDE0MDYgMC44MDQ2ODggMTAuNDkyMTg4IDIuMjM4MjgxIDExLjc1NzgxMiBDIDIuNDY4NzUgMTEuNTM5MDYyIDIuNzM4MjgxIDExLjM1NTQ2OSAzLjAzNTE1NiAxMS4yMjY1NjIgQyAxLjY3OTY4OCAxMC4xMDkzNzUgMC45MTc5NjkgOC43MzgyODEgMC45MTc5NjkgNy4zMzIwMzEgQyAwLjkxNzk2OSAzLjc5Njg3NSA1LjQ0MTQwNiAwLjkxNzk2OSAxMSAwLjkxNzk2OSBDIDE2LjU1ODU5NCAwLjkxNzk2OSAyMS4wODIwMzEgMy43OTY4NzUgMjEuMDgyMDMxIDcuMzMyMDMxIEMgMjEuMDgyMDMxIDguNzUzOTA2IDIwLjM0Mzc1IDEwLjEwMTU2MiAxOC45ODgyODEgMTEuMjE4NzUgTCAxOS44Mzk4NDQgMTEuNjg3NSBDIDIxLjIyNjU2MiAxMC40Mzc1IDIyIDguOTEwMTU2IDIyIDcuMzMyMDMxIEMgMjIgMy4yODkwNjIgMTcuMDY2NDA2IDAgMTEgMCBaIE0gMTEgMCAiLz4KPC9nPgo8L3N2Zz4K), auto'
+        document.getElementById('layers').style.cursor =
+          'url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMjJwdCIgaGVpZ2h0PSIyMnB0IiB2aWV3Qm94PSIwIDAgMjIgMjIiIHZlcnNpb249IjEuMSI+CjxnIGlkPSJzdXJmYWNlMSI+CjxwYXRoIHN0eWxlPSIgc3Ryb2tlOm5vbmU7ZmlsbC1ydWxlOm5vbnplcm87ZmlsbDpyZ2IoMCUsMCUsMCUpO2ZpbGwtb3BhY2l0eToxOyIgZD0iTSA0LjQ0OTIxOSAxNC44MDA3ODEgQyA0LjI2OTUzMSAxNC42MjEwOTQgMy45ODA0NjkgMTQuNjIxMDk0IDMuODAwNzgxIDE0LjgwMDc4MSBDIDMuNjIxMDk0IDE0Ljk4MDQ2OSAzLjYyMTA5NCAxNS4yNjk1MzEgMy44MDA3ODEgMTUuNDQ5MjE5IEMgNS43Njk1MzEgMTcuNDE3OTY5IDUuNzY5NTMxIDE5LjI1IDMuODAwNzgxIDIxLjIxODc1IEMgMy42MjEwOTQgMjEuMzk4NDM4IDMuNjIxMDk0IDIxLjY4NzUgMy44MDA3ODEgMjEuODY3MTg4IEMgMy44OTA2MjUgMjEuOTU3MDMxIDQuMDA3ODEyIDIyIDQuMTI1IDIyIEMgNC4yNDIxODggMjIgNC4zNTkzNzUgMjEuOTU3MDMxIDQuNDQ5MjE5IDIxLjg2NzE4OCBDIDYuNzU3ODEyIDE5LjU1NDY4OCA2Ljc1NzgxMiAxNy4xMTMyODEgNC40NDkyMTkgMTQuODAwNzgxIFogTSA0LjQ0OTIxOSAxNC44MDA3ODEgIi8+CjxwYXRoIHN0eWxlPSIgc3Ryb2tlOm5vbmU7ZmlsbC1ydWxlOm5vbnplcm87ZmlsbDpyZ2IoMCUsMCUsMCUpO2ZpbGwtb3BhY2l0eToxOyIgZD0iTSA0LjEyNSAxMS45MTc5NjkgQyAzLjExMzI4MSAxMS45MTc5NjkgMi4yOTI5NjkgMTIuNzM4MjgxIDIuMjkyOTY5IDEzLjc1IEMgMi4yOTI5NjkgMTQuNzYxNzE5IDMuMTEzMjgxIDE1LjU4MjAzMSA0LjEyNSAxNS41ODIwMzEgQyA1LjEzNjcxOSAxNS41ODIwMzEgNS45NTcwMzEgMTQuNzYxNzE5IDUuOTU3MDMxIDEzLjc1IEMgNS45NTcwMzEgMTIuNzM4MjgxIDUuMTM2NzE5IDExLjkxNzk2OSA0LjEyNSAxMS45MTc5NjkgWiBNIDQuMTI1IDE0LjY2Nzk2OSBDIDMuNjIxMDk0IDE0LjY2Nzk2OSAzLjIwNzAzMSAxNC4yNTM5MDYgMy4yMDcwMzEgMTMuNzUgQyAzLjIwNzAzMSAxMy4yNDYwOTQgMy42MjEwOTQgMTIuODMyMDMxIDQuMTI1IDEyLjgzMjAzMSBDIDQuNjI4OTA2IDEyLjgzMjAzMSA1LjA0Mjk2OSAxMy4yNDYwOTQgNS4wNDI5NjkgMTMuNzUgQyA1LjA0Mjk2OSAxNC4yNTM5MDYgNC42Mjg5MDYgMTQuNjY3OTY5IDQuMTI1IDE0LjY2Nzk2OSBaIE0gNC4xMjUgMTQuNjY3OTY5ICIvPgo8cGF0aCBzdHlsZT0iIHN0cm9rZTpub25lO2ZpbGwtcnVsZTpub256ZXJvO2ZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiIGQ9Ik0gMjEuNzY1NjI1IDEzLjgwODU5NCBMIDEzLjUxNTYyNSA5LjIyMjY1NiBDIDEzLjM0Mzc1IDkuMTI4OTA2IDEzLjEzNjcxOSA5LjE1MjM0NCAxMi45ODgyODEgOS4yODEyNSBDIDEyLjg0Mzc1IDkuNDEwMTU2IDEyLjc5Mjk2OSA5LjYxMzI4MSAxMi44NjcxODggOS43OTY4NzUgTCAxNi41MzEyNSAxOC45NjA5MzggQyAxNi42MDE1NjIgMTkuMTMyODEyIDE2Ljc2OTUzMSAxOS4yNSAxNi45NTMxMjUgMTkuMjUgQyAxNi45NTMxMjUgMTkuMjUgMTYuOTU3MDMxIDE5LjI1IDE2Ljk1NzAzMSAxOS4yNSBDIDE3LjE0MDYyNSAxOS4yNSAxNy4zMDg1OTQgMTkuMTQwNjI1IDE3LjM3ODkwNiAxOC45NzI2NTYgTCAxOC42ODM1OTQgMTUuOTMzNTk0IEwgMjEuNzIyNjU2IDE0LjYyODkwNiBDIDIxLjg4MjgxMiAxNC41NjI1IDIxLjk4ODI4MSAxNC40MDYyNSAyMiAxNC4yMzA0NjkgQyAyMi4wMDc4MTIgMTQuMDU4NTk0IDIxLjkxNzk2OSAxMy44OTQ1MzEgMjEuNzY1NjI1IDEzLjgwODU5NCBaIE0gMjEuNzY1NjI1IDEzLjgwODU5NCAiLz4KPHBhdGggc3R5bGU9IiBzdHJva2U6bm9uZTtmaWxsLXJ1bGU6bm9uemVybztmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7IiBkPSJNIDUuNjY0MDYyIDEyLjc2NTYyNSBDIDUuNTc4MTI1IDEyLjYyODkwNiA1LjQ3MjY1NiAxMi41MDc4MTIgNS4zNTU0NjkgMTIuNDAyMzQ0IEMgNS4zMzk4NDQgMTIuMzg2NzE5IDUuMzI0MjE5IDEyLjM3NSA1LjMwODU5NCAxMi4zNjMyODEgQyA1LjIxMDkzOCAxMi4yNzczNDQgNS4xMDU0NjkgMTIuMjA3MDMxIDQuOTkyMTg4IDEyLjE0NDUzMSBDIDQuOTYwOTM4IDEyLjEyODkwNiA0LjkyOTY4OCAxMi4xMDkzNzUgNC44OTg0MzggMTIuMDkzNzUgQyA0Ljc3MzQzOCAxMi4wMzUxNTYgNC42NDQ1MzEgMTEuOTg4MjgxIDQuNTA3ODEyIDExLjk1NzAzMSBDIDQuNDY4NzUgMTEuOTQ5MjE5IDQuNDI1NzgxIDExLjk0OTIxOSA0LjM4MjgxMiAxMS45NDE0MDYgQyA0LjI2OTUzMSAxMS45MjU3ODEgNC4xNTIzNDQgMTEuOTE3OTY5IDQuMDM5MDYyIDExLjkyNTc4MSBDIDMuNjMyODEyIDExLjk0NTMxMiAzLjI2NTYyNSAxMi4wOTc2NTYgMi45Njg3NSAxMi4zMzU5MzggQyAzLjE5MTQwNiAxMi40OTYwOTQgMy40MTQwNjIgMTIuNjQ4NDM4IDMuNjU2MjUgMTIuNzkyOTY5IEMgMy43NSAxMi44NDc2NTYgMy44NTkzNzUgMTIuODY3MTg4IDMuOTY4NzUgMTIuODUxNTYyIEMgNC4zNDc2NTYgMTIuNzg1MTU2IDQuNzUzOTA2IDEyLjk3NjU2MiA0LjkzNzUgMTMuMzM1OTM4IEMgNC45ODgyODEgMTMuNDMzNTk0IDUuMDcwMzEyIDEzLjUxMTcxOSA1LjE2Nzk2OSAxMy41NTA3ODEgQyA1LjQyMTg3NSAxMy42NTYyNSA1LjY4NzUgMTMuNzM4MjgxIDUuOTQ5MjE5IDEzLjgyODEyNSBDIDUuOTQ5MjE5IDEzLjgwMDc4MSA1Ljk1NzAzMSAxMy43NzczNDQgNS45NTcwMzEgMTMuNzUgQyA1Ljk1NzAzMSAxMy4zODY3MTkgNS44NDc2NTYgMTMuMDUwNzgxIDUuNjY0MDYyIDEyLjc2NTYyNSBaIE0gNS42NjQwNjIgMTIuNzY1NjI1ICIvPgo8cGF0aCBzdHlsZT0iIHN0cm9rZTpub25lO2ZpbGwtcnVsZTpub256ZXJvO2ZpbGw6cmdiKDAlLDAlLDAlKTtmaWxsLW9wYWNpdHk6MTsiIGQ9Ik0gMTMuMzgyODEyIDEzLjU1ODU5NCBDIDExLjE5MTQwNiAxMy44OTg0MzggOC44NTkzNzUgMTMuNzUgNi44MDQ2ODggMTMuMTUyMzQ0IEMgNi44NDc2NTYgMTMuMzQzNzUgNi44NzUgMTMuNTQyOTY5IDYuODc1IDEzLjc1IEMgNi44NzUgMTMuODcxMDk0IDYuODU1NDY5IDEzLjk4ODI4MSA2LjgzOTg0NCAxNC4xMDkzNzUgQyA4LjE1NjI1IDE0LjQ2ODc1IDkuNTY2NDA2IDE0LjY2Nzk2OSAxMSAxNC42Njc5NjkgQyAxMS45MjU3ODEgMTQuNjY3OTY5IDEyLjgzOTg0NCAxNC41ODIwMzEgMTMuNzM0Mzc1IDE0LjQyOTY4OCBaIE0gMTMuMzgyODEyIDEzLjU1ODU5NCAiLz4KPHBhdGggc3R5bGU9IiBzdHJva2U6bm9uZTtmaWxsLXJ1bGU6bm9uemVybztmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7IiBkPSJNIDExIDAgQyA0LjkzMzU5NCAwIDAgMy4yODkwNjIgMCA3LjMzMjAzMSBDIDAgOC45NDE0MDYgMC44MDQ2ODggMTAuNDkyMTg4IDIuMjM4MjgxIDExLjc1NzgxMiBDIDIuNDY4NzUgMTEuNTM5MDYyIDIuNzM4MjgxIDExLjM1NTQ2OSAzLjAzNTE1NiAxMS4yMjY1NjIgQyAxLjY3OTY4OCAxMC4xMDkzNzUgMC45MTc5NjkgOC43MzgyODEgMC45MTc5NjkgNy4zMzIwMzEgQyAwLjkxNzk2OSAzLjc5Njg3NSA1LjQ0MTQwNiAwLjkxNzk2OSAxMSAwLjkxNzk2OSBDIDE2LjU1ODU5NCAwLjkxNzk2OSAyMS4wODIwMzEgMy43OTY4NzUgMjEuMDgyMDMxIDcuMzMyMDMxIEMgMjEuMDgyMDMxIDguNzUzOTA2IDIwLjM0Mzc1IDEwLjEwMTU2MiAxOC45ODgyODEgMTEuMjE4NzUgTCAxOS44Mzk4NDQgMTEuNjg3NSBDIDIxLjIyNjU2MiAxMC40Mzc1IDIyIDguOTEwMTU2IDIyIDcuMzMyMDMxIEMgMjIgMy4yODkwNjIgMTcuMDY2NDA2IDAgMTEgMCBaIE0gMTEgMCAiLz4KPC9nPgo8L3N2Zz4K), auto'
       }
-      document.elementsFromPoint(mouseX, mouseY)
+      document
+        .elementsFromPoint(mouseX, mouseY)
         .map(x => {
           switch (x.tagName) {
             case 'path':
@@ -463,11 +488,22 @@ export function drag_selector_installer(svg_elem) {
           }
         })
         .filter(x => {
-          if (typeof (x) == 'undefined' || typeof (x.classList) == 'undefined') return false
+          if (typeof x == 'undefined' || typeof x.classList == 'undefined') return false
           var shiftKey = event.shiftKey
-          return (x.classList.contains('relation') && !x.classList.contains('relation--filtered') && !x.classList.contains('selectedrelation') && !x.classList.contains('extraselectedrelation') && !shiftKey)
-            || (x.classList.contains('note') && !x.classList.contains('selectednote') && !x.classList.contains('extraselectednote'))
-            || (x.classList.contains('metarelation') && !x.classList.contains('selectedrelation') && !x.classList.contains('extraselectedrelation') && !shiftKey)
+          return (
+            (x.classList.contains('relation') &&
+              !x.classList.contains('relation--filtered') &&
+              !x.classList.contains('selectedrelation') &&
+              !x.classList.contains('extraselectedrelation') &&
+              !shiftKey) ||
+            (x.classList.contains('note') &&
+              !x.classList.contains('selectednote') &&
+              !x.classList.contains('extraselectednote')) ||
+            (x.classList.contains('metarelation') &&
+              !x.classList.contains('selectedrelation') &&
+              !x.classList.contains('extraselectedrelation') &&
+              !shiftKey)
+          )
         })
         .forEach(toggle_selected)
     }
@@ -502,18 +538,20 @@ export function adjust_top(draw_context, ydiff) {
   var x, y, w, h
 
   if (!draw_context.old_viewbox) {
-    [x, y, w, h] = svg_viewbox.split(' ')
+    ;[x, y, w, h] = svg_viewbox.split(' ')
     draw_context.old_viewbox = svg_viewbox
     draw_context.old_height = svg_height
   } else {
-    [x, y, w, h] = draw_context.old_viewbox.split(' ')
+    ;[x, y, w, h] = draw_context.old_viewbox.split(' ')
     svg_height = draw_context.old_height
   }
-  svg_elem.getElementsByClassName('definition-scale')[0].setAttribute('viewBox', [x, Number(y) - ydiff, w, Number(h) + ydiff].join(' '))
+  svg_elem
+    .getElementsByClassName('definition-scale')[0]
+    .setAttribute('viewBox', [x, Number(y) - ydiff, w, Number(h) + ydiff].join(' '))
 
   var svg_num_height = Number(svg_height.split('p')[0]) // Assume "XYZpx"
   // change height
-  svg_elem.children[0].setAttribute('height', (svg_num_height * ((h - (y - ydiff)) / (h - y))) + 'px')
+  svg_elem.children[0].setAttribute('height', svg_num_height * ((h - (y - ydiff)) / (h - y)) + 'px')
 }
 
 export function hide_top(draw_context) {
@@ -521,7 +559,9 @@ export function hide_top(draw_context) {
   var id_prefix = draw_context.id_prefix
   var something_to_clear = clear_top(draw_context)
   if (something_to_clear) {
-    svg_elem.getElementsByClassName('definition-scale')[0].setAttribute('viewBox', draw_context.old_viewbox)
+    svg_elem
+      .getElementsByClassName('definition-scale')[0]
+      .setAttribute('viewBox', draw_context.old_viewbox)
     svg_elem.children[0].setAttribute('height', draw_context.old_height)
   }
 }
@@ -532,8 +572,7 @@ function hide_orphan_notes() {
   var gn_ids = Array.from(mei_graph.getElementsByTagName('arc')).map(e => e.getAttribute('to'))
   ids.forEach(i => {
     var ii = i.replace(/(^\d+-?)/, '') // Replace layer or view prefixes.
-    if (!gn_ids.includes(`#gn-${ii}`))
-      document.getElementById(i).classList.add('hidden')
+    if (!gn_ids.includes(`#gn-${ii}`)) document.getElementById(i).classList.add('hidden')
   })
 }
 
@@ -548,7 +587,7 @@ export function toggle_orphan_notes() {
 
 // Functions helping to interact with variable declared here from other files.
 export const getPlacingNote = () => placing_note
-export const setPlacingNote = value => placing_note = value
+export const setPlacingNote = value => (placing_note = value)
 
 export const getCurrentDrawContext = () => current_draw_context
 export const setCurrentDrawContext = drawContext => {
@@ -583,7 +622,10 @@ export function adjustSvgDimensions(draw_context) {
   }
 
   // Calculate bounding box of all relations
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity
 
   const allElements = [...allRelations, ...allMetarelations]
   allElements.forEach(relation => {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1107,6 +1107,9 @@ function count_existing_slurs(noteElement) {
 // Draw a slur between two notes
 export function draw_slur(startNote, endNote, isDownward) {
   const newElement = document.createElementNS('http://www.w3.org/2000/svg', 'path')
+  var draw_contexts = getDrawContexts()
+  const curvature_factor = draw_contexts.curvatureFactor || .5
+  const stroke_width = 20 + curvature_factor * 50
 
   // Get base coordinates
   const start = note_coords(startNote)
@@ -1116,70 +1119,47 @@ export function draw_slur(startNote, endNote, isDownward) {
   const nStartSlur = count_existing_slurs(startNote)
   const nEndSlur = count_existing_slurs(endNote)
 
-  // Base offset plus additional offset per existing slur
-  const baseOffsetY = 150
-  const slurOffsetYUnit = 30
-  const startOffsetY = isDownward ? (nStartSlur * slurOffsetYUnit) - baseOffsetY : baseOffsetY - (nStartSlur * slurOffsetYUnit)
-  const endOffsetY = isDownward ? (nEndSlur * slurOffsetYUnit) - baseOffsetY : baseOffsetY - (nEndSlur * slurOffsetYUnit)
-
   // Apply offsets
-  const adjustedStart = [start[0], start[1] - startOffsetY]
-  const adjustedEnd = [end[0], end[1] - endOffsetY]
+  const adjustedStart = [start[0], start[1]]
+  const adjustedEnd = [end[0], end[1]]
 
   // Calculate base height and additional height for existing slurs
-  const slurOffsetHeightUnit = 100
+  const slurOffsetHeightUnit = 150 + stroke_width * 2
   const maxExistingSlurs = Math.max(nStartSlur, nEndSlur)
   const additionalHeight = maxExistingSlurs * slurOffsetHeightUnit
   const width = Math.abs(adjustedEnd[0] - adjustedStart[0])
+  const heightHeadwise = Math.abs(adjustedEnd[1] - adjustedStart [1])
   const maxSlurWidth = 100
 
   let pathData
 
-  // Adjust control points based on different start/end heights
-  if (width < 3800) {
-    const height = width * 0.3 + additionalHeight
-    const heightDiff = Math.abs(startOffsetY - endOffsetY)
-    const midX = (adjustedStart[0] + adjustedEnd[0]) / 2
-    const midY = (adjustedStart[1] + adjustedEnd[1]) / 2
-    const topControlPoint = isDownward ? [midX, midY + height + (heightDiff * 0.5)] : [midX, midY - height - (heightDiff * 0.5)]
-    const bottomControlPoint = isDownward ? [midX, midY + height + (heightDiff * 0.5) - maxSlurWidth] : [midX, midY - height - (heightDiff * 0.5) + maxSlurWidth]
+  const minY = Math.min(adjustedStart[1], adjustedEnd[1])
+  const maxY = Math.max(adjustedStart[1], adjustedEnd[1])
 
-    pathData = `
-      M ${adjustedStart[0]},${adjustedStart[1]}
-      Q ${topControlPoint[0]},${topControlPoint[1]} ${adjustedEnd[0]},${adjustedEnd[1]}
-      L ${adjustedEnd[0]},${adjustedEnd[1]}
-      Q ${bottomControlPoint[0]},${bottomControlPoint[1]} ${adjustedStart[0]},${adjustedStart[1]}
-      Z`
-  } else {
-    const height = additionalHeight + Math.min(width * 0.05, 2000)
-    const minY = Math.min(adjustedStart[1], adjustedEnd[1])
-    const maxY = Math.max(adjustedStart[1], adjustedEnd[1])
+  // Calculate two control points on axes that are perpendicular to the linear segment between the start and end of the slur,
+  // and intersect that segment at 20% and 80% of its length, so that the four points together form a trapezoid.
+  const cpMult = isDownward ? 1 : -1
+  const cpScaler = 4 * curvature_factor / Math.log(width) + additionalHeight / 5000
+  const cp1x = (4 * adjustedStart[0] + adjustedEnd[0]) / 5 - cpMult * cpScaler * (adjustedEnd[1] - adjustedStart[1])
+  const cp2x = (adjustedStart[0] + 4 * adjustedEnd[0]) / 5 - cpMult * cpScaler * (adjustedEnd[1] - adjustedStart[1])
+  const cp1y = (4 * adjustedStart[1] + adjustedEnd[1]) / 5 + cpMult * cpScaler * (adjustedEnd[0] - adjustedStart[0])
+  const cp2y = (adjustedStart[1] + 4 * adjustedEnd[1]) / 5 + cpMult * cpScaler * (adjustedEnd[0] - adjustedStart[0])
 
-    // Calculate control points at 20% and 80% of the width
-    const cp1x = adjustedStart[0] + (width * 0.2)
-    const cp2x = adjustedStart[0] + (width * 0.8)
+  const topCP1 = [cp1x, cp1y]
+  const topCP2 = [cp2x, cp2y]
+  const bottomCP1 = topCP1
+  const bottomCP2 = topCP2
 
-    // Set control points at the same height for flat top
-    const topY = isDownward ? maxY + height : minY - height
-
-    // Top curve control points
-    const topCP1 = [cp1x, topY]
-    const topCP2 = [cp2x, topY]
-
-    // Bottom curve control points (offset by maxWidth)
-    const bottomCP1 = isDownward ? [cp1x, topY - maxSlurWidth] : [cp1x, topY + maxSlurWidth]
-    const bottomCP2 = isDownward ? [cp2x, topY - maxSlurWidth] : [cp2x, topY + maxSlurWidth]
-
-    pathData = `
-      M ${adjustedStart[0]},${adjustedStart[1]}
-      C ${topCP1[0]},${topCP1[1]} ${topCP2[0]},${topCP2[1]} ${adjustedEnd[0]},${adjustedEnd[1]}
-      L ${adjustedEnd[0]},${adjustedEnd[1]}
-      C ${bottomCP2[0]},${bottomCP2[1]} ${bottomCP1[0]},${bottomCP1[1]} ${adjustedStart[0]},${adjustedStart[1]}
-      Z`
-
-  }
+  pathData = `
+    M ${adjustedStart[0]},${adjustedStart[1]}
+    C ${topCP1[0]},${topCP1[1]} ${topCP2[0]},${topCP2[1]} ${adjustedEnd[0]},${adjustedEnd[1]}
+    L ${adjustedEnd[0]},${adjustedEnd[1]}
+    C ${bottomCP2[0]},${bottomCP2[1]} ${bottomCP1[0]},${bottomCP1[1]} ${adjustedStart[0]},${adjustedStart[1]}
+    Z`
+  // }
 
   newElement.setAttribute('d', pathData)
+  newElement.setAttribute('style', `stroke-width:${stroke_width}`)
   return newElement
 }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1182,3 +1182,9 @@ export function draw_slur(startNote, endNote, isDownward) {
   newElement.setAttribute('d', pathData)
   return newElement
 }
+
+export function isSlurDownward(svg_elem, startNote, endNote) {
+  let system_bbox = svg_elem.querySelector('svg.definition-scale').getBBox()
+  let system_mid = system_bbox.y + system_bbox.height / 2
+  return system_mid < note_coords(startNote)[1] && system_mid < note_coords(endNote)[1]
+}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1164,7 +1164,7 @@ export function draw_slur(startNote, endNote, isDownward) {
 }
 
 export function isSlurDownward(svg_elem, startNote, endNote) {
-  let system_bbox = svg_elem.querySelector('svg.definition-scale').getBBox()
+  let system_bbox = svg_elem.querySelector('.system').getBBox()
   let system_mid = system_bbox.y + system_bbox.height / 2
   return system_mid < note_coords(startNote)[1] && system_mid < note_coords(endNote)[1]
 }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1105,7 +1105,7 @@ function count_existing_slurs(noteElement) {
 }
 
 // Draw a slur between two notes
-export function draw_slur(startNote, endNote) {
+export function draw_slur(startNote, endNote, isDownward) {
   const newElement = document.createElementNS('http://www.w3.org/2000/svg', 'path')
 
   // Get base coordinates
@@ -1119,8 +1119,8 @@ export function draw_slur(startNote, endNote) {
   // Base offset plus additional offset per existing slur
   const baseOffsetY = 150
   const slurOffsetYUnit = 30
-  const startOffsetY = baseOffsetY + (nStartSlur * slurOffsetYUnit)
-  const endOffsetY = baseOffsetY + (nEndSlur * slurOffsetYUnit)
+  const startOffsetY = isDownward ? (nStartSlur * slurOffsetYUnit) - baseOffsetY : baseOffsetY - (nStartSlur * slurOffsetYUnit)
+  const endOffsetY = isDownward ? (nEndSlur * slurOffsetYUnit) - baseOffsetY : baseOffsetY - (nEndSlur * slurOffsetYUnit)
 
   // Apply offsets
   const adjustedStart = [start[0], start[1] - startOffsetY]
@@ -1141,8 +1141,8 @@ export function draw_slur(startNote, endNote) {
     const heightDiff = Math.abs(startOffsetY - endOffsetY)
     const midX = (adjustedStart[0] + adjustedEnd[0]) / 2
     const midY = (adjustedStart[1] + adjustedEnd[1]) / 2
-    const topControlPoint = [midX, midY - height - (heightDiff * 0.5)]
-    const bottomControlPoint = [midX, midY - height - (heightDiff * 0.5) + maxSlurWidth]
+    const topControlPoint = isDownward ? [midX, midY + height + (heightDiff * 0.5)] : [midX, midY - height - (heightDiff * 0.5)]
+    const bottomControlPoint = isDownward ? [midX, midY + height + (heightDiff * 0.5) - maxSlurWidth] : [midX, midY - height - (heightDiff * 0.5) + maxSlurWidth]
 
     pathData = `
       M ${adjustedStart[0]},${adjustedStart[1]}
@@ -1152,22 +1152,23 @@ export function draw_slur(startNote, endNote) {
       Z`
   } else {
     const height = additionalHeight + Math.min(width * 0.05, 2000)
-    const minY = Math.min(startOffsetY, endOffsetY)
+    const minY = Math.min(adjustedStart[1], adjustedEnd[1])
+    const maxY = Math.max(adjustedStart[1], adjustedEnd[1])
 
     // Calculate control points at 20% and 80% of the width
     const cp1x = adjustedStart[0] + (width * 0.2)
     const cp2x = adjustedStart[0] + (width * 0.8)
 
     // Set control points at the same height for flat top
-    const topY = minY - height
+    const topY = isDownward ? maxY + height : minY - height
 
     // Top curve control points
     const topCP1 = [cp1x, topY]
     const topCP2 = [cp2x, topY]
 
     // Bottom curve control points (offset by maxWidth)
-    const bottomCP1 = [cp1x, topY + maxSlurWidth]
-    const bottomCP2 = [cp2x, topY + maxSlurWidth]
+    const bottomCP1 = isDownward ? [cp1x, topY - maxSlurWidth] : [cp1x, topY + maxSlurWidth]
+    const bottomCP2 = isDownward ? [cp2x, topY - maxSlurWidth] : [cp2x, topY + maxSlurWidth]
 
     pathData = `
       M ${adjustedStart[0]},${adjustedStart[1]}


### PR DESCRIPTION
This PR builds on and replaces PR #290. It addresses issue #285.

In addition to the changes of #290, it:

- uses a trapezoidal arrangement of anchor and control points that enables slurs to "nest" and scale better;
- improves the appearance and shape of long slurs using a logarithmic function;
- unifies the drawing of "short" and "long" slurs into a single algorithm;
- makes slur curvature and thickness dynamically user-adjustable;
- fixes vertical slurs, which originally had certain artifacts due to their horizontally aligned control points;
- eliminates the need for start and end offsets;
- improves the separation of slurs spanning the same two notes;
- determines the direction of slurs (upwards/downwards) based on the SVG of the score system itself (i.e. excluding any annotations);
- fixes various edge cases with slurs.
