### PR TITLE
Do not clip score top on zoom. Ensure all annotations are visible.

### DIFF
--- a/src/public/css/style.css
+++ b/src/public/css/style.css
@@ -450,6 +450,8 @@ body:not(.mousedown) .extraselectedrelation:hover rect{
   padding-left: 255px; /* Should be greater than the width of `filterdiv`, which is now removed. */
   transform-origin: left center;
   overflow: visible;
+  padding-top: 30px;
+  transform-origin: 0 0;
 }
 
 .svg_container svg {


### PR DESCRIPTION
Fixes #295 and ensures that the topmost annotations will not be clipped out on score load.

