### PR TITLE
Fix scroll for relation & metarelation

### DIFF
--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -164,8 +164,11 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
     'wheel',
     e => {
       e.preventDefault()
-      flip_to_bg(e.target)
-      e.target.onmouseout()
+      flip_to_bg(e.target.closest('g'))
+      // Only call onmouseout if it exists
+      if (e.target.onmouseout) {
+        e.target.onmouseout()
+      }
     },
     captureEvent
   )

--- a/src/js/draw.js
+++ b/src/js/draw.js
@@ -27,7 +27,8 @@ import {
   relation_type,
   draw_slur,
   isSlurDownward,
-  get_by_id
+  get_by_id,
+  handleFlip
 } from './utils'
 
 // Given a draw context and a graph node representing a relation, draw the
@@ -159,19 +160,7 @@ export function draw_relation(draw_context, mei_graph, g_elem) {
   if (!newApp.ui.scoreSettings.brightShades)
     toggle_shade(elem)
 
-  // Relations can be scrolled
-  group.addEventListener(
-    'wheel',
-    e => {
-      e.preventDefault()
-      flip_to_bg(e.target.closest('g'))
-      // Only call onmouseout if it exists
-      if (e.target.onmouseout) {
-        e.target.onmouseout()
-      }
-    },
-    captureEvent
-  )
+  group.addEventListener('wheel', handleFlip, captureEvent)
 
   // Decorate with onclick and onmouseover handlers
   group.onclick = () => {
@@ -473,15 +462,8 @@ export function draw_metarelation(draw_context, mei_graph, g_elem) {
   if (!newApp.ui.scoreSettings.brightShades)
     toggle_shade(g_elem)
 
-  // We can scroll among metarelations as well
-  g_elem.addEventListener('wheel', e => {
-    e.preventDefault()
-    flip_to_bg(e.target.closest('g'))
-    // Only call onmouseout if it exists
-    if (e.target.onmouseout) {
-      e.target.onmouseout()
-    }
-  }, captureEvent)
+  // We can scroll among metarelations with wheel
+  g_elem.addEventListener('wheel', handleFlip, captureEvent)
 
   // Decorate with onclick and onmouseover handlers
   g_elem.onclick = () => toggle_selected(g_elem)

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -284,11 +284,11 @@ export function handle_keypress(ev) {
   } else if (ev.key == action_conf.move_relation_to_front) {
     // Scroll through relations
     var elem = document.elementFromPoint(mouseX, mouseY)
-    if (elem.tagName == 'circle') elem = elem.closest('g')
+    if (elem.tagName != 'g') elem = elem.closest('g')
     flip_to_bg(elem)
     if (elem.onmouseout) elem.onmouseout()
     var elem = document.elementFromPoint(mouseX, mouseY)
-    if (elem.tagName == 'circle') elem = elem.closest('g')
+    if (elem.tagName != 'g') elem = elem.closest('g')
     document.dispatchEvent(
       new CustomEvent('fliprelation', {
         detail: {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1168,3 +1168,12 @@ export function isSlurDownward(svg_elem, startNote, endNote) {
   let system_mid = system_bbox.y + system_bbox.height / 2
   return system_mid < note_coords(startNote)[1] && system_mid < note_coords(endNote)[1]
 }
+
+export function handleFlip(e) {
+  e.preventDefault()
+  flip_to_bg(e.target.closest('g'))
+  // Only call onmouseout if it exists
+  if (e.target.onmouseout) {
+    e.target.onmouseout()
+  }
+}


### PR DESCRIPTION
> - [x] Hovering over a "buried" relation and pressing z (or rolling the scroll wheel) crashes and produces an error in the terminal.
> - [x] Hovering over a "buried" meta-relation (or rolling the scroll wheel) works. However the z shortcut does not.

refs: #294 