### PR TITLE
Instantiate MIDI Player before referencing.

### DIFF
--- a/src/js/new/modules/Player/index.js
+++ b/src/js/new/modules/Player/index.js
@@ -9,7 +9,9 @@ import { clamp, round } from '../../utils/math'
 import ProgressBar from './progress'
 
 const audioContext = new AudioContext()
-let midiPlayer
+let midiPlayer = new MidiPlayer.Player(function(event) {
+  console.log(event)
+})
 
 class Player {
   constructor() {


### PR DESCRIPTION
Fixes a lingering bug in #309 (in response to #267).
