### PR TITLE
Fix the zoom level of the snapshots made from reductions

### DIFF
--- a/src/js/bootstrap.js
+++ b/src/js/bootstrap.js
@@ -712,6 +712,12 @@ export function create_new_layer(sliced = false, tied = false) {
   newSvgCont.style.width = oldSvgCont.style.width
   newSvgCont.style.height = oldSvgCont.style.height
 
+  newApp.ui.zoom.initSvg(
+    newSvgCont
+      .getElementsByTagName('svg')[0]
+      .getElementsByClassName('definition-scale')[0]
+  )
+
   newApp.ui.zoom.setScale(newApp.ui.zoom.state.scale)
 
   return new_draw_context


### PR DESCRIPTION
Addresses #398 
Note: If a snapshot is applied from a reduction, the SVG that will be rendered over the reduction will likely be shorter but should be of the overall same size. The layer might also be smaller because of the relations missing from the reduction (no useless whitespaces in the layer)